### PR TITLE
Improve Arena Compare UX, graph loading, and contest flow.

### DIFF
--- a/components/ArenaBatchFab.tsx
+++ b/components/ArenaBatchFab.tsx
@@ -70,7 +70,21 @@ const ArenaBatchFab: React.FC = () => {
     }
   };
 
-  if (!mounted || count < 1) return null;
+  const hideOnArenaCompare = useMemo(() => {
+    if (loc.pathname !== '/climb') return false;
+    try {
+      const lid = new URLSearchParams(loc.search).get('list')?.trim();
+      if (!lid) return false;
+      const raw = sessionStorage.getItem(`inturank-arena-contest-flow-v1:${lid}`);
+      if (!raw) return false;
+      const parsed = JSON.parse(raw) as { phase?: string };
+      return parsed?.phase === 'compare';
+    } catch {
+      return false;
+    }
+  }, [loc.pathname, loc.search]);
+
+  if (!mounted || count < 1 || hideOnArenaCompare) return null;
 
   return createPortal(
     <button

--- a/components/ArenaLeaderboardGlance.tsx
+++ b/components/ArenaLeaderboardGlance.tsx
@@ -54,10 +54,32 @@ const ArenaLeaderboardGlance: React.FC<Props> = ({
    * reflects the just-completed batch instead of the empty "Be the first ranker" splash.
    */
   const augmentedPlayers = useMemo<ArenaPlayerRow[]>(() => {
+    const sortRanked = (rows: ArenaPlayerRow[]) =>
+      [...rows]
+        .sort((a, b) => inturankLeaderboardTotalXp(b) - inturankLeaderboardTotalXp(a))
+        .map((m, i) => ({ ...m, rank: i + 1 }));
+
+    const bridgeViewer = (rows: ArenaPlayerRow[]) => {
+      if (!myAddrLc) return rows;
+      return rows.map((p) =>
+        p.address === myAddrLc
+          ? {
+              ...p,
+              arenaXp: Math.max(p.arenaXp, myArenaXp),
+              activityXp: Math.max(p.activityXp, myActivityXp),
+            }
+          : p,
+      );
+    };
+
     const myTotal = inturankLeaderboardTotalXp({ arenaXp: myArenaXp, activityXp: myActivityXp });
-    if (!myAddrLc || myTotal <= 0) return players;
+    if (!myAddrLc) return players;
+
     const exists = players.some((p) => p.address === myAddrLc);
-    if (exists) return players;
+    if (exists) return sortRanked(bridgeViewer(players));
+
+    if (myTotal <= 0) return players;
+
     const synthetic: ArenaPlayerRow = {
       rank: 0,
       address: myAddrLc,
@@ -69,22 +91,16 @@ const ArenaLeaderboardGlance: React.FC<Props> = ({
       listsPlayed: 0,
       updatedAt: 0,
     };
-    const merged = [...players, synthetic].sort(
-      (a, b) => inturankLeaderboardTotalXp(b) - inturankLeaderboardTotalXp(a),
-    );
-    return merged.map((m, i) => ({ ...m, rank: i + 1 }));
+    return sortRanked(bridgeViewer([...players, synthetic]));
   }, [players, myAddrLc, myArenaXp, myActivityXp]);
 
   const myRow = useMemo(
     () => (myAddrLc ? augmentedPlayers.find((p) => p.address === myAddrLc) ?? null : null),
     [augmentedPlayers, myAddrLc],
   );
-  /**
-   * Single source for "You" breakdown: when already on the fetched board, match the row used for the podium
-   * (indexer/mirror + merged activity). Props alone use `max(indexer, pick credit)` for Arena and can differ by a few XP.
-   */
-  const youArenaXp = myRow ? myRow.arenaXp : myArenaXp;
-  const youActivityXp = myRow ? myRow.activityXp : myActivityXp;
+  /** Same totals as Climb uplink badge (`max(indexer, device pick credit)` + activity). */
+  const youArenaXp = myArenaXp;
+  const youActivityXp = myActivityXp;
   const top3 = augmentedPlayers.slice(0, 3);
 
   return (
@@ -312,7 +328,7 @@ const ArenaLeaderboardGlance: React.FC<Props> = ({
               )}
             </div>
             <div className="text-right shrink-0 space-y-1.5 tabular-nums">
-              <div title="Arena XP as counted on this leaderboard (indexer / mirror). Session strip may bridge pick credit until the graph catches up.">
+              <div title="Arena XP — indexer plus device pick credit until the graph catches up (matches Climb uplink).">
                 <p className={`text-[8px] font-mono uppercase tracking-wider font-bold leading-none ${isLight ? 'text-sky-800/90' : 'text-cyan-300/85'}`}>Arena</p>
                 <p
                   className="text-base font-black leading-none mt-0.5"

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -750,7 +750,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
           </div>
         </main>
 
-        {ARENA_BATCH_MODE && <ArenaBatchFab />}
+        {ARENA_BATCH_MODE && !pathname.startsWith('/climb') && <ArenaBatchFab />}
 
         <SiteFooter />
       </div>

--- a/components/MobileLayout.tsx
+++ b/components/MobileLayout.tsx
@@ -355,7 +355,7 @@ const MobileLayout: React.FC<Props> = ({ children }) => {
         <SiteFooter compact />
       </main>
 
-      {ARENA_BATCH_MODE && <ArenaBatchFab />}
+      {ARENA_BATCH_MODE && !location.pathname.startsWith('/climb') && <ArenaBatchFab />}
 
       {/* Floating bottom tab bar — pill, five equal tabs (matches mobile reference pattern). */}
       <nav

--- a/components/SignalFeed.tsx
+++ b/components/SignalFeed.tsx
@@ -1,5 +1,5 @@
 /**
- * Signal / Pulse stance queue plus Vouch flows.
+ * Signal — Pulse (stance queue + markets) · Vouch (on-chain name claims).
  */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
@@ -59,7 +59,6 @@ import {
 } from '../services/signalPulseCache';
 import { submitSignalVouchesOnChain } from '../services/signalVouchOnchain';
 import { submitSignalStancesOnChain } from '../services/signalStanceOnchain';
-import { isUserRejectedWalletError, parseProtocolError } from '../services/web3';
 import {
   getSignalPendingForWallet,
   getSignalVouchesForWallet,
@@ -124,10 +123,10 @@ function shortPredicate(label: string): string {
   return trimmed;
 }
 
-/** Short tag chip (profile row tone, not raw triple syntax). */
+/** Teal tag chip text — short so names + labels read like a profile row, not a raw triple dump. */
 function shortTag(text: string, max = 22): string {
   const t = text.trim();
-  if (!t) return '…';
+  if (!t) return '—';
   if (t.length <= max) return t;
   return `${t.slice(0, Math.max(1, max - 1))}…`;
 }
@@ -227,7 +226,7 @@ const SignalFeed: React.FC<Props> = ({ className, viewerAddress }) => {
       setAtomCardsErrorTrending(null);
     } catch (e: unknown) {
       setAtomCardsTrending((prev) => (prev.length ? prev : []));
-      setAtomCardsErrorTrending(e instanceof Error ? e.message : 'Could not load Hot identities');
+      setAtomCardsErrorTrending(e instanceof Error ? e.message : 'Could not load Hot atoms');
     } finally {
       setAtomCardsLoadingTrending(false);
     }
@@ -261,7 +260,7 @@ const SignalFeed: React.FC<Props> = ({ className, viewerAddress }) => {
       setAtomCardsErrorNetwork(null);
     } catch (e: unknown) {
       setAtomCardsNetwork((prev) => (prev.length ? prev : []));
-      setAtomCardsErrorNetwork(e instanceof Error ? e.message : 'Could not load Crowd identities');
+      setAtomCardsErrorNetwork(e instanceof Error ? e.message : 'Could not load Crowd atoms');
     } finally {
       setAtomCardsLoadingNetwork(false);
     }
@@ -336,7 +335,7 @@ const SignalFeed: React.FC<Props> = ({ className, viewerAddress }) => {
       });
     } catch (e: unknown) {
       if (gen !== yoursFetchGen.current) return;
-      setYoursError(e instanceof Error ? e.message : 'Could not load tracked identities');
+      setYoursError(e instanceof Error ? e.message : 'Could not load your atoms');
       setYoursCards([]);
     } finally {
       if (gen === yoursFetchGen.current) setYoursLoading(false);
@@ -541,7 +540,7 @@ const SignalFeed: React.FC<Props> = ({ className, viewerAddress }) => {
       if (result.reason === 'added') toast.success(`Queued · ${stance === 'stand' ? 'Support' : 'Oppose'}`);
       else if (result.reason === 'flipped')
         toast.info(
-          `${stance === 'stand' ? 'Support' : 'Oppose'} queued. Submit from the conviction cart (new deposit, not an instant flip).`,
+          `${stance === 'stand' ? 'Support' : 'Oppose'} queued — submit from the conviction cart (new deposit, not an instant flip).`,
         );
       else toast.info('Removed from queue');
     },
@@ -605,14 +604,7 @@ const SignalFeed: React.FC<Props> = ({ className, viewerAddress }) => {
       setVouchTick((n) => n + 1);
       void loadNamedBundle();
     } catch (e: unknown) {
-      if (isUserRejectedWalletError(e)) {
-        toast.info('Signing was cancelled. Your queued vouches are unchanged.');
-      } else {
-        const parsed = parseProtocolError(e).trim();
-        const msg =
-          parsed || (e instanceof Error ? e.message : '') || 'Vouch submit failed';
-        toast.error(msg.length > 420 ? `${msg.slice(0, 417)}…` : msg);
-      }
+      toast.error(e instanceof Error ? e.message : 'Vouch submit failed');
     } finally {
       setVouchSubmitBusy(false);
     }
@@ -687,14 +679,7 @@ const SignalFeed: React.FC<Props> = ({ className, viewerAddress }) => {
         /* ignore */
       }
     } catch (e: unknown) {
-      if (isUserRejectedWalletError(e)) {
-        toast.info('Signing was cancelled. Your Pulse queue is unchanged.');
-      } else {
-        const parsed = parseProtocolError(e).trim();
-        const msg =
-          parsed || (e instanceof Error ? e.message : '') || 'Stance submit failed';
-        toast.error(msg.length > 420 ? `${msg.slice(0, 417)}…` : msg);
-      }
+      toast.error(e instanceof Error ? e.message : 'Stance submit failed');
     } finally {
       setStanceSubmitBusy(false);
     }
@@ -747,10 +732,10 @@ const SignalFeed: React.FC<Props> = ({ className, viewerAddress }) => {
           </div>
           <div className="min-w-0">
             <p className="text-[11px] font-mono font-black uppercase tracking-[0.28em] text-cyan-200">
-              IntuRank Signal
+              IntuRank · Signal
             </p>
             <p className="text-[13px] text-slate-200 leading-snug mt-0.5">
-              Queue Pulse stances, then open <strong className="text-cyan-300/95">Review cart</strong> below (same conviction cart pattern as Arena).
+              Queue Pulse stances, then open <strong className="text-cyan-300/95">Review cart</strong> below — same flow as the Arena conviction cart.
             </p>
           </div>
         </div>
@@ -795,7 +780,7 @@ const SignalFeed: React.FC<Props> = ({ className, viewerAddress }) => {
         />
       </div>
 
-      {/* Body switches per Pulse vs Vouch lane */}
+      {/* Body — switches per lane */}
       <AnimatePresence mode="wait">
         {lane === 'pulse' ? (
           <motion.div
@@ -1096,7 +1081,7 @@ const PulseYoursSearchModal: React.FC<{
       className="fixed inset-0 z-[80] flex items-end sm:items-center justify-center p-3 sm:p-6 bg-black/70 backdrop-blur-[2px]"
       role="dialog"
       aria-modal="true"
-      aria-label="Search identities to track"
+      aria-label="Search atoms to add"
       onMouseDown={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
@@ -1106,7 +1091,7 @@ const PulseYoursSearchModal: React.FC<{
         onMouseDown={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between gap-2 px-4 py-3 border-b border-white/[0.08]">
-          <p className="text-[12px] font-black uppercase tracking-[0.2em] text-white">Add identity</p>
+          <p className="text-[12px] font-black uppercase tracking-[0.2em] text-white">Add atom</p>
           <button
             type="button"
             onClick={() => {
@@ -1122,7 +1107,7 @@ const PulseYoursSearchModal: React.FC<{
         </div>
         <div className="p-3 border-b border-white/[0.06]">
           <label className="sr-only" htmlFor="pulse-yours-search">
-            Search Intuition graph
+            Search Intuition atoms
           </label>
           <div className="flex items-center gap-2 rounded-xl border border-white/[0.12] bg-black/50 px-3 py-2">
             <Search size={16} className="text-cyan-400/90 shrink-0" />
@@ -1388,7 +1373,7 @@ const PulseLane: React.FC<{
               Queue Support or Oppose on the <strong className="text-cyan-200">identity claim rail</strong> above, then submit from the conviction cart.
             </p>
             <p className="text-[11px] text-slate-500 mt-3 max-w-md mx-auto leading-relaxed">
-              If you just confirmed on-chain, stakes can take a few minutes to appear while the indexer syncs. Use{' '}
+              If you just confirmed on-chain, stakes can take a few minutes to show here while the indexer catches up — use{' '}
               <strong className="text-slate-400">Refresh</strong> at the top of Signal.
             </p>
           </div>
@@ -1407,7 +1392,7 @@ const PulseLane: React.FC<{
         <div className="flex items-center justify-between gap-2 px-1">
           <p className="text-[12px] text-slate-300">
             <strong className="text-white tabular-nums">{meStances.length}</strong> stake{meStances.length === 1 ? '' : 's'} ·
-            <span className="text-slate-400"> showing {start + 1} to {start + pageRows.length}</span>
+            <span className="text-slate-400"> showing {start + 1}–{start + pageRows.length}</span>
           </p>
           <Link
             to="/portfolio"
@@ -1490,7 +1475,7 @@ const PulseLane: React.FC<{
                         ? 'bg-amber-500/25 border-amber-300/60 text-amber-50'
                         : 'border-white/15 bg-black/40 text-slate-100 hover:text-white hover:border-white/40'
                     }`}
-                    title={`Queue ${it.support ? 'Oppose' : 'Support'} in the conviction cart. You confirm a separate vault deposit here (not a one-tap flip).`}
+                    title={`Queue ${it.support ? 'Oppose' : 'Support'} in the conviction cart — you submit a separate vault deposit; this is not a one-tap “flip” like some other apps.`}
                   >
                     <ArrowLeftRight size={13} strokeWidth={2.3} />
                     {oppositeQueued
@@ -1572,7 +1557,7 @@ const PulseLane: React.FC<{
             <div className="flex flex-col items-center gap-2 py-16">
               <Loader2 className="w-7 h-7 text-cyan-300 animate-spin" />
               <span className="text-[12px] font-semibold uppercase tracking-widest text-slate-300">
-                Loading your identities…
+                Loading your atoms…
               </span>
             </div>
           ) : !yoursHasIds ? (
@@ -1580,8 +1565,8 @@ const PulseLane: React.FC<{
               <Hash className="mx-auto mb-2 text-cyan-300" size={22} />
               <p className="text-[14px] text-white font-semibold">Nothing saved yet.</p>
               <p className="text-[12px] text-slate-400 mt-2 max-w-sm mx-auto">
-                Heart identities on <strong className="text-cyan-200">Hot</strong> or{' '}
-                <strong className="text-cyan-200">Crowd</strong>, or search to add one.
+                Heart atoms on <strong className="text-cyan-200">Hot</strong>/<strong className="text-cyan-200">Crowd</strong>,
+                or search to add.
               </p>
               <button
                 type="button"
@@ -1593,7 +1578,7 @@ const PulseLane: React.FC<{
                 className="mt-5 inline-flex items-center gap-2 rounded-full border border-cyan-400/55 bg-cyan-500/15 px-5 py-2.5 text-[12px] font-bold uppercase tracking-wider text-cyan-50 hover:bg-cyan-500/25"
               >
                 <Plus size={16} />
-                Search identities
+                Search atoms
               </button>
             </div>
           ) : (
@@ -1610,7 +1595,7 @@ const PulseLane: React.FC<{
               {!yoursLoading && yoursCards.length === 0 && !yoursError ? (
                 <div className="rounded-2xl border border-white/[0.08] bg-black/40 px-6 py-8 text-center">
                   <p className="text-[13px] text-slate-300 max-w-md mx-auto leading-relaxed">
-                    No claims loaded for these identities yet. Try <strong className="text-cyan-200">Refresh</strong> or{' '}
+                    No claims for these atoms yet. Try <strong className="text-cyan-200">Refresh</strong> or{' '}
                     <strong className="text-cyan-200">Add</strong>.
                   </p>
                 </div>
@@ -1699,7 +1684,7 @@ const PulseLane: React.FC<{
 };
 
 /* -------------------------------------------------------------------------- */
-/* Pulse identity cards rail */
+/* Pulse · Identity atom cards — portal-style rail (teal tags + stake + gold thumbs)            */
 /* -------------------------------------------------------------------------- */
 
 /** Hide redundant “has tag” line; show predicate when it adds meaning (graph-driven). */
@@ -1765,10 +1750,10 @@ const PulseAtomTagSection: React.FC<{
 
   const atomsHeading =
     rail === 'yours'
-      ? 'Your identities'
+      ? 'Your atoms'
       : atomTone === 'crowd'
-        ? 'Identities (live order)'
-        : 'Identities (spotlight)';
+        ? 'Atoms · live order'
+        : 'Atoms · curated heat';
 
   const gridClass = 'grid grid-cols-1 lg:grid-cols-2 gap-4 items-start';
 
@@ -1776,8 +1761,9 @@ const PulseAtomTagSection: React.FC<{
     return (
       <div className="space-y-3">
         <p className="px-1 text-[11px] font-medium text-slate-500 max-w-xl">
-          Each card resolves that identity from the graph, then loads triples and vault stats (same depth as a market row).
-          First load pulls many subgraph calls; Hot and Crowd results cache in this browser afterward.
+          Each card loads that identity on the Intuition graph, then triples and vault stats per atom (the same depth
+          as a market claim view). That means many requests—first load is slower; Hot and Crowd are then cached in
+          this browser for a while.
         </p>
         <div className={gridClass}>
           {Array.from({ length: 4 }).map((_, i) => (
@@ -1899,7 +1885,7 @@ const PulseAtomTagSection: React.FC<{
             }}
             onMouseEnter={playHover}
             className="shrink-0 inline-flex items-center gap-1.5 rounded-xl border border-cyan-400/50 bg-cyan-500/15 px-3 py-2 text-[11px] font-bold uppercase tracking-wider text-cyan-50 hover:bg-cyan-500/25 transition-colors duration-200"
-            title="Search identities"
+            title="Search atoms"
           >
             <Plus size={14} strokeWidth={2.4} />
             Add
@@ -2003,7 +1989,7 @@ const PulseAtomTagCard: React.FC<{
   const slotKind = card.pulseSlotKind;
   const emptySlotCopy =
     slotKind === 'unresolved'
-      ? 'Label not indexed yet; the subgraph may still be syncing.'
+      ? 'Not indexed under this label yet — the graph may be catching up.'
       : slotKind === 'empty_claims'
         ? 'Atom resolved, but no “has tag” claims with vaults are wired for this slot yet.'
         : 'Nothing on this page.';
@@ -2310,7 +2296,7 @@ const VouchLane: React.FC<{
         <Shield className="mx-auto mb-3 text-amber-300" size={28} />
         <p className="text-[13px] text-slate-200 font-semibold">No `.eth` / `.trust` rows from the graph.</p>
         <p className="text-[12px] text-slate-400 mt-2 leading-relaxed">
-          Refresh pulls vault identities and the accounts index. Names can lag until the indexer finishes.
+          Refresh pulls vault atoms and the accounts index. If the subgraph lags, names can appear after sync.
         </p>
       </div>
     );
@@ -2329,7 +2315,7 @@ const VouchLane: React.FC<{
           <div className="min-w-0">
             <h2 className="text-xl sm:text-2xl font-black font-display text-white leading-tight">Vouch</h2>
             <p className="text-[14px] text-slate-200 leading-relaxed mt-1">
-              Queue trust for the handles below, then submit the full batch from the bar when ready.
+              Queue trust for the handles below — submit the whole batch from the bar when you&rsquo;re ready.
             </p>
             <p className="text-[12px] font-mono uppercase tracking-[0.16em] text-slate-300 mt-2">
               {sorted.length} names · heavier vaults first

--- a/components/SignalStanceCartModal.tsx
+++ b/components/SignalStanceCartModal.tsx
@@ -131,7 +131,7 @@ const SignalStanceCartModal: React.FC<Props> = ({
                     Conviction cart
                   </h2>
                   <p className="text-[10px] text-slate-500 font-mono mt-1 truncate">
-                    Pulse · <span className="text-intuition-primary/90">{txCount} claim{txCount === 1 ? '' : 's'}</span>
+                    Pulse · <span className="text-intuition-primary/90">{picks.length} claim{picks.length === 1 ? '' : 's'}</span>
                     <span className="text-slate-600"> · </span>
                     <span className="text-amber-200/90 tabular-nums">{trustTotalLabel} TRUST</span>
                   </p>

--- a/components/SkillChat.tsx
+++ b/components/SkillChat.tsx
@@ -37,7 +37,6 @@ import {
   createTripleFromLabels,
   looksLikeBytes32TermId,
   inferFeeProxyActionFromCalldata,
-  isUserRejectedWalletError,
 } from '../services/web3';
 import {
     CURRENCY_SYMBOL,
@@ -96,7 +95,15 @@ function newSkillMessageId(): string {
     return `skill-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
 }
 
-/** GraphQL in a ```json fence: skip tx parser (avoid false positives on read-only answers). */
+function isUserRejectionError(err: unknown): boolean {
+    const e = err as { code?: number | string; cause?: { code?: number }; message?: string; shortMessage?: string };
+    const code = e?.code ?? e?.cause?.code;
+    if (code === 4001 || code === 'ACTION_REJECTED') return true;
+    const s = `${e?.message ?? ''} ${e?.shortMessage ?? ''}`.toLowerCase();
+    return /user reject|rejected|denied|cancel|cancelled|4001|action_rejected|user denied|request rejected|wallet.*reject|rejected the request/i.test(s);
+}
+
+/** GraphQL or prose was fenced as ```json — do not run JSON5 tx parser (avoids false "Could not build transaction" on read-only answers). */
 function looksLikeGraphQLFencedAsJson(raw: string): boolean {
     const s = raw.trim();
     if (s.startsWith('{')) return false;
@@ -168,7 +175,7 @@ function skillTxActionDisplayLabel(intent: Record<string, unknown> | null | unde
     if (!intent) return 'Protocol transaction';
     if (isTripleFromLabelsIntent(intent)) return 'Triple (claim)';
     const a = resolveSkillTxAction(intent);
-    if (a === 'createAtoms') return 'Create identity';
+    if (a === 'createAtoms') return 'Create atom(s)';
     if (a === 'createTriples') return 'Create claim(s)';
     if (a === 'deposit') return 'Vault deposit';
     if (a === 'tripleFromLabels') return 'Triple (claim)';
@@ -286,7 +293,7 @@ function parsedRecordLooksLikeShellTemplate(parsed: Record<string, unknown>): bo
     return false;
 }
 
-/** Triple vault deposit (protocol default); models often hallucinate "10". */
+/** Triple vault deposit — matches protocol prompt; LLMs often hallucinate "10". */
 const DEFAULT_TRIPLE_DEPOSIT_TRUST = '0.5';
 
 function normalizeTripleDepositTrust(raw: unknown): string {
@@ -296,16 +303,16 @@ function normalizeTripleDepositTrust(raw: unknown): string {
     return s;
 }
 
-/** Resolution note for triple preview (same rules as on-chain term resolution). */
+/** Explains how subject/predicate/object are resolved — matches web3 resolveAtomReferenceToTermId. */
 function tripleUiResolutionLine(subject: string, predicate: string, object: string): string {
     const n = [subject, predicate, object].filter((x) => looksLikeBytes32TermId(x)).length;
     if (n === 3) {
-        return 'All three are hex term IDs. The graph reuses those on-chain identities (no new mints for them).';
+        return 'All three are term IDs — existing on-chain atoms are reused for them (no new atom transactions for those values).';
     }
     if (n > 0) {
-        return 'Hex IDs bind to existing identities when present; plain text only mints if that name is not on-chain yet.';
+        return 'Hex term IDs use existing atoms on-chain when present; plain-text labels only create atoms if that name does not exist yet.';
     }
-    return 'Plain labels: new identities mint first if needed, then the claim (one wallet prompt per new identity).';
+    return 'Text labels: missing atoms are created first when needed, then the triple (one wallet prompt per new atom).';
 }
 
 /** Prefer first non-empty string among keys (LLMs use subject vs subjectId, etc.). */
@@ -417,7 +424,7 @@ async function tryRescueBuiltInCreateAtomAfterBadSkillJson(
                 data: built.data,
                 value: built.valueWei.toString(),
                 chainId: String(CHAIN_ID),
-                description: `Create identity "${onChainName}"`,
+                description: `Create atom "${onChainName}"`,
                 txBuiltIn: true,
                 builtinLabel: onChainName,
                 builtinDepositTrust: depositTrust,
@@ -457,7 +464,7 @@ const DEFAULT_SKILL_MESSAGES: Message[] = [
         id: 'skill-seed-welcome',
         role: 'assistant',
         content:
-            "Hi. I use the full upstream Intuition skill package (schemas, GraphQL, deposits, simulation) plus IntuRank routing. Ask protocol questions or say what to create (an identity, or a claim like “Alice / trusts / Bob” with 0.5 TRUST). Connect your wallet to Sign & broadcast. If you see Enable fee proxy, run it once before your first write.",
+            "Hi. I run on the full upstream Intuition skill package (SKILL.md, GraphQL reference, schemas, workflows, deposit/redeem batch ops, simulation, fees) plus IntuRank-specific routing. Ask deep protocol questions or tell me what to create (atom or a claim like “Alice / trusts / Bob” with a 0.5 TRUST deposit). I reply in your language when I can. Connect your wallet when you are ready to Sign & broadcast. Before your first on-chain create, use Enable fee proxy in the bar if it appears (one time).",
     },
 ];
 
@@ -547,7 +554,8 @@ function AssistantMessageBody({ content }: { content: string }) {
                 <pre className="max-h-[min(360px,55vh)] overflow-auto border-t border-white/[0.06] p-3.5 text-[10px] leading-relaxed text-slate-300 font-mono whitespace-pre-wrap [overflow-wrap:anywhere] rounded-b-2xl">
                     {display || (
                         <span className="text-slate-500 italic font-sans">
-                            No JSON fence here. Ask for one fenced JSON payload only.
+                            No JSON in this block — the model may have skipped the payload or used a non-standard fence. Ask again for a
+                            fenced JSON code block only.
                         </span>
                     )}
                 </pre>
@@ -773,7 +781,7 @@ const SkillChat: React.FC<SkillChatProps> = ({ className = '' }) => {
                             const depositTrust = String(parsed.depositTrust ?? '0').trim();
                             if (isPlaceholderAtomLabel(label)) {
                                 contentAppend =
-                                    '\n\n_(No on-chain preview: use a specific identity name in your message.)_';
+                                    '\n\n_(No on-chain preview: use a specific atom name in your message if you want to create one.)_';
                             } else {
                             const built = await buildCreateAtomTxIntent(address, label, depositTrust);
                             const onChainName = normalizeAtomLabel(label);
@@ -786,7 +794,7 @@ const SkillChat: React.FC<SkillChatProps> = ({ className = '' }) => {
                                 description:
                                     typeof parsed.description === 'string'
                                         ? parsed.description
-                                        : `Create identity "${onChainName}"`,
+                                        : `Create atom "${onChainName}"`,
                                 txBuiltIn: true,
                                 builtinLabel: onChainName,
                                 builtinDepositTrust: depositTrust,
@@ -801,7 +809,7 @@ const SkillChat: React.FC<SkillChatProps> = ({ className = '' }) => {
                         const object = strFromParsed(p, 'object', 'objectId', 'objectTermId');
                         const depositTrust = normalizeTripleDepositTrust(parsed.depositTrust);
                         if (!subject || !predicate || !object) {
-                            contentAppend = '\n\n_(createTriple JSON needs subject, predicate, and object fields, or subjectId/predicateId/objectId hex term ids.)_';
+                            contentAppend = '\n\n_(createTriple JSON needs subject, predicate, and object — or subjectId / predicateId / objectId as hex term ids.)_';
                         } else {
                             txIntent = {
                                 action: 'tripleFromLabels',
@@ -828,8 +836,8 @@ const SkillChat: React.FC<SkillChatProps> = ({ className = '' }) => {
                         if (shell) {
                             txIntent = null;
                             txBlockedReason =
-                                'This JSON looks like a **shell walkthrough** (placeholders such as $MULTIVAULT). That is not signable calldata.\n\n' +
-                                `Ask again for **one** \`createAtom\` JSON: \`"action": "createAtom"\`, \`label\`, \`depositTrust\`, \`chainId": "${CHAIN_ID}"\`. No numbered steps, no curl/cast, no $ variables.`;
+                                'This JSON block is from a **shell walkthrough** (placeholders like $MULTIVAULT, 0x$CALLDATA, or $(…)). Those are not real addresses or calldata — the app cannot open a wallet for them.\n\n' +
+                                `Ask again for **only** one \`createAtom\` JSON: \`"action": "createAtom"\`, \`label\`, \`depositTrust\`, \`chainId": "${CHAIN_ID}"\` — no numbered steps, no \`curl\`/\`cast\`, no \`$\` variables.`;
                             logSkillEvent({
                                 level: 'warn',
                                 event: 'skill.chat.tx_intent_shell_template',
@@ -846,7 +854,7 @@ const SkillChat: React.FC<SkillChatProps> = ({ className = '' }) => {
                                     (enriched.value != null && String(enriched.value).trim() !== '');
                                 if (partial) {
                                     txBlockedReason =
-                                        'Cannot sign raw MultiVault payloads here. For a mint, use **`createAtom`** JSON with `label` and `depositTrust` (FeeProxy path).';
+                                        'This JSON cannot be signed: a raw transaction needs a real FeeProxy **`to`** address and **`data`** hex. For creating an atom, use the **`createAtom`** shape (`label`, `depositTrust`) instead of MultiVault/shell output.';
                                 }
                             } else {
                                 const rawErr = getRawSkillBroadcastValidationError(enriched);
@@ -953,15 +961,11 @@ const SkillChat: React.FC<SkillChatProps> = ({ className = '' }) => {
                     markProxyApproved(address);
                 }
             } catch (setupErr: unknown) {
-                const userRejected = isUserRejectedWalletError(setupErr);
+                const userRejected = isUserRejectionError(setupErr);
                 const errText = userRejected
-                    ? ''
+                    ? "Protocol approval cancelled in wallet"
                     : parseProtocolError(setupErr) || extractErrorText(setupErr) || "Network or protocol setup failed";
-                if (userRejected) {
-                    toast.info('Cancelled in wallet. Enable fee proxy when you are ready, then retry.');
-                } else {
-                    toast.error(errText.length > 140 ? errText.slice(0, 137) + '…' : errText);
-                }
+                toast.error(errText.length > 140 ? errText.slice(0, 137) + "…" : errText);
                 setMessages((prev) =>
                     prev.map((msgItem, idx) =>
                         idx === messageIndex
@@ -999,7 +1003,7 @@ const SkillChat: React.FC<SkillChatProps> = ({ className = '' }) => {
                     depositTrustWei: parseEther(String(intent.depositTrust ?? '0.5')),
                   });
                 } else {
-                  toast.success('This claim already exists on-chain. Open it below (no duplicate tx).');
+                  toast.success('This claim already exists on-chain — open it below (no duplicate tx).');
                 }
                 logSkillEvent({
                     level: 'info',
@@ -1027,7 +1031,7 @@ const SkillChat: React.FC<SkillChatProps> = ({ className = '' }) => {
                     )
                 );
             } catch (error: unknown) {
-                const userRejected = isUserRejectedWalletError(error);
+                const userRejected = isUserRejectionError(error);
                 const errText = parseProtocolError(error) || extractErrorText(error) || "Triple pipeline failed";
                 const shortErr = errText.length > 160 ? errText.slice(0, 157) + "…" : errText;
                 setMessages((prev) =>
@@ -1041,7 +1045,7 @@ const SkillChat: React.FC<SkillChatProps> = ({ className = '' }) => {
                             : msgItem
                     )
                 );
-                if (userRejected) toast.info("Cancelled in wallet. Connect and try again when ready.");
+                if (userRejected) toast.error("Transaction cancelled in wallet");
                 else toast.error(shortErr.length > 140 ? shortErr.slice(0, 137) + "…" : shortErr);
                 logSkillEvent({
                     level: userRejected ? 'info' : 'warn',
@@ -1091,15 +1095,11 @@ const SkillChat: React.FC<SkillChatProps> = ({ className = '' }) => {
                 }
             }
         } catch (setupErr: unknown) {
-            const userRejected = isUserRejectedWalletError(setupErr);
+            const userRejected = isUserRejectionError(setupErr);
             const errText = userRejected
-                ? ''
+                ? "Protocol approval cancelled in wallet"
                 : parseProtocolError(setupErr) || extractErrorText(setupErr) || "Network or protocol setup failed";
-            if (userRejected) {
-                toast.info('Cancelled in wallet. Enable fee proxy when you are ready, then retry.');
-            } else {
-                toast.error(errText.length > 140 ? errText.slice(0, 137) + "…" : errText);
-            }
+            toast.error(errText.length > 140 ? errText.slice(0, 137) + "…" : errText);
             setMessages((prev) =>
                 prev.map((msgItem, idx) =>
                     idx === messageIndex
@@ -1207,7 +1207,7 @@ const SkillChat: React.FC<SkillChatProps> = ({ className = '' }) => {
                 )
             );
         } catch (error: unknown) {
-            const userRejected = isUserRejectedWalletError(error);
+            const userRejected = isUserRejectionError(error);
             const errText = parseProtocolError(error) || extractErrorText(error) || "Execution failed";
             const shortErr = errText.length > 160 ? errText.slice(0, 157) + "…" : errText;
             setMessages((prev) =>
@@ -1222,7 +1222,7 @@ const SkillChat: React.FC<SkillChatProps> = ({ className = '' }) => {
                 )
             );
             if (userRejected) {
-                toast.info("Cancelled in wallet.");
+                toast.error("Transaction cancelled in wallet");
             } else {
                 toast.error(shortErr.length > 140 ? shortErr.slice(0, 137) + "…" : shortErr);
             }
@@ -1301,7 +1301,7 @@ const SkillChat: React.FC<SkillChatProps> = ({ className = '' }) => {
                     ) : (
                         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                             <p className="text-xs text-amber-100/90 leading-snug min-w-0 font-sans">
-                                Enable IntuRank fee proxy for identities, claims, and deposits (one wallet approval).
+                                Enable IntuRank fee proxy for atoms, claims, and deposits. One wallet approval.
                             </p>
                             <button
                                 type="button"
@@ -1316,12 +1316,7 @@ const SkillChat: React.FC<SkillChatProps> = ({ className = '' }) => {
                                         setProtocolReady(true);
                                         toast.success('IntuRank fee proxy enabled.');
                                     } catch (e: unknown) {
-                                        const rej = isUserRejectedWalletError(e);
-                                        toast[rej ? 'info' : 'error'](
-                                            rej
-                                                ? 'Cancelled in wallet.'
-                                                : parseProtocolError(e) || extractErrorText(e) || 'Could not enable protocol',
-                                        );
+                                        toast.error(parseProtocolError(e) || extractErrorText(e) || 'Could not enable protocol');
                                     } finally {
                                         setEnablingProtocol(false);
                                     }
@@ -1439,11 +1434,10 @@ const SkillChat: React.FC<SkillChatProps> = ({ className = '' }) => {
                                             {m.txBlockedReason}
                                         </p>
                                         <p className="text-[11px] leading-relaxed text-slate-500 font-sans border-t border-white/10 pt-3">
-                                            Example prompt: “Output{' '}
-                                            <span className="text-slate-400">only</span>{' '}
-                                            <code className="text-cyan-200/90">createAtom</code>{' '}
-                                            JSON for <span className="text-white font-semibold">Video Calls</span> with{' '}
-                                            depositTrust 0.5. No shell steps.”
+                                            Example prompt: “Output <span className="text-slate-400">only</span> the{' '}
+                                            <code className="text-cyan-200/90">createAtom</code> JSON for{' '}
+                                            <span className="text-white font-semibold">Video Calls</span>, depositTrust 0.5 — no
+                                            shell steps.”
                                         </p>
                                     </div>
                                 )}
@@ -1544,7 +1538,7 @@ const SkillChat: React.FC<SkillChatProps> = ({ className = '' }) => {
                                                     <>
                                                         {m.txIntent.txBuiltIn && (
                                                             <p className="mb-3 rounded-xl border border-cyan-500/25 bg-cyan-500/10 px-3 py-2 text-xs font-medium text-cyan-200/95">
-                                                                New identity (built in-app)
+                                                                New atom (built in-app)
                                                             </p>
                                                         )}
                                                         <div className="grid gap-2">
@@ -1555,7 +1549,7 @@ const SkillChat: React.FC<SkillChatProps> = ({ className = '' }) => {
                                                             {m.txIntent.txBuiltIn && m.txIntent.builtinLabel != null && (
                                                                 <>
                                                                     <div className="grid grid-cols-[minmax(4.25rem,auto)_1fr] items-start gap-x-3 gap-y-1 rounded-xl border border-white/[0.06] bg-white/[0.03] px-3 py-2.5">
-                                                                        <span className="pt-0.5 text-[10px] font-semibold uppercase tracking-wide text-slate-500">Identity</span>
+                                                                        <span className="pt-0.5 text-[10px] font-semibold uppercase tracking-wide text-slate-500">Atom</span>
                                                                         <span className="text-right font-bold text-white break-all">{m.txIntent.builtinLabel}</span>
                                                                     </div>
                                                                     <div className="grid grid-cols-[minmax(4.25rem,auto)_1fr] items-start gap-x-3 gap-y-1 rounded-xl border border-white/[0.06] bg-white/[0.03] px-3 py-2.5">
@@ -1606,7 +1600,7 @@ const SkillChat: React.FC<SkillChatProps> = ({ className = '' }) => {
                                                 </div>
                                                 <p className="text-xs text-amber-100/90 font-sans leading-relaxed [overflow-wrap:anywhere]">
                                                     {isTripleFromLabelsIntent(m.txIntent)
-                                                        ? 'If prompted, approve the identity batch first (one signature for new anchors), then the claim.'
+                                                        ? 'Approve atom batch if prompted (one signature for all new anchors), then the claim.'
                                                         : 'Approve or reject in your wallet.'}
                                                 </p>
                                             </div>
@@ -1619,14 +1613,14 @@ const SkillChat: React.FC<SkillChatProps> = ({ className = '' }) => {
                                                 </p>
                                                 <p className="text-sm text-slate-300 font-sans leading-relaxed">
                                                     {isTripleFromLabelsIntent(m.txIntent) && !m.txHash && m.txTermId
-                                                        ? 'Nothing new to mint. This claim was already on-chain.'
+                                                        ? 'Nothing new to mint — this claim was already on-chain.'
                                                         : 'Your transaction is on-chain.'}
                                                 </p>
                                                 {m.txAtomHashes && m.txAtomHashes.length > 0 && (
                                                     <p className="text-xs text-slate-500 font-sans leading-relaxed">
                                                         {m.txAtomHashes.length === 1
-                                                            ? 'New identities anchored in one batched transaction. View on explorer.'
-                                                            : `Signed ${m.txAtomHashes.length} identity transactions. View on explorer.`}
+                                                            ? 'Atoms anchored in one batched transaction — see explorer.'
+                                                            : `Signed ${m.txAtomHashes.length} atom transactions — see explorer for details.`}
                                                     </p>
                                                 )}
                                                 {m.txHash ? (
@@ -1644,7 +1638,7 @@ const SkillChat: React.FC<SkillChatProps> = ({ className = '' }) => {
                                                 ) : (
                                                     <p className="text-xs font-sans text-slate-500">
                                                         {isTripleFromLabelsIntent(m.txIntent) && m.txTermId
-                                                            ? 'No new transaction hash because the claim already existed. Use Open claim.'
+                                                            ? 'No transaction hash — claim already existed (use Open claim).'
                                                             : 'Hash unavailable.'}
                                                     </p>
                                                 )}
@@ -1665,7 +1659,7 @@ const SkillChat: React.FC<SkillChatProps> = ({ className = '' }) => {
                                                             className="inline-flex items-center justify-center gap-2 rounded-2xl bg-emerald-500 px-5 py-3 font-sans text-sm font-bold text-black shadow-[0_10px_36px_rgba(16,185,129,0.35)] transition-transform hover:bg-emerald-400 active:scale-[0.99]"
                                                         >
                                                             <ExternalLink size={16} />
-                                                            {isTripleFromLabelsIntent(m.txIntent) ? 'Open claim' : 'Open identity'}
+                                                            {isTripleFromLabelsIntent(m.txIntent) ? 'Open claim' : 'Open atom'}
                                                         </Link>
                                                     )}
                                                 </div>
@@ -1833,9 +1827,9 @@ const SkillChat: React.FC<SkillChatProps> = ({ className = '' }) => {
                 </div>
                 <div className="mt-2.5 flex snap-x snap-mandatory gap-2 overflow-x-auto overflow-y-visible pb-1 scrollbar-none [-webkit-overflow-scrolling:touch]">
                     {[
-                        { short: 'Create an identity', full: 'Create an identity named IntuRank Sandbox with 0.5 TRUST deposit' },
+                        { short: 'Create an atom', full: 'Create an atom called IntuRank Sandbox with 0.5 TRUST deposit' },
                         { short: 'Alice trusts Bob', full: 'Create a triple: subject Alice, predicate trusts, object Bob, deposit 0.5 TRUST' },
-                        { short: 'Identities vs claims', full: 'What is the difference between an identity term and a triple claim?' },
+                        { short: 'Atoms vs triples', full: 'What is the difference between an atom and a triple?' },
                         { short: 'Contract addresses', full: 'What are the FeeProxy and MultiVault addresses used in this app?' },
                     ].map((suggestion, i) => (
                         <button

--- a/components/arenaFlow/ArenaCompareView.tsx
+++ b/components/arenaFlow/ArenaCompareView.tsx
@@ -1,8 +1,10 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
+import { useReducedMotion } from 'framer-motion';
 import { Link } from 'react-router-dom';
 import {
   ArrowRight,
   CheckCircle2,
+  ChevronDown,
   Crown,
   Layers,
   Loader2,
@@ -18,7 +20,10 @@ import {
   Zap,
 } from 'lucide-react';
 import type { ArenaComparePeer, RankItem } from '../../pages/RankedList';
+import { parseStakeBaseLabel } from '../../services/arenaRankStake';
+import type { PortalListRankRow } from '../../services/arenaSimilarity';
 import { playArenaUiClick, playArenaUiHover } from '../../services/audio';
+import { CURRENCY_SYMBOL } from '../../constants';
 import {
   ARENA_CARD_SURFACE,
   ARENA_SHADOWS,
@@ -30,6 +35,10 @@ import { ArenaPortraitImg } from './ArenaPortraitImg';
 
 type Props = {
   deck: RankItem[];
+  /** Per-item stake units from Rank (× session stake base). */
+  rankTrustUnits?: Record<string, number>;
+  /** Session stake preset label, e.g. "0.1". */
+  stakeBaseLabel?: string;
   /** Drives the contest's solid color theme. */
   listCategory?: string;
   /** Real-data peers (sorted DESC by similarity). Empty when no on-chain overlap. */
@@ -61,6 +70,8 @@ type Props = {
   /** Opens batch review so the user can sign queued rows (this list or others). */
   onOpenConvictionCart?: () => void;
   onOpenSignal?: () => void;
+  /** Compare step: only “Play random game” + “Choose new game” (stakes signed on Rank/mint). */
+  gameActionsOnly?: boolean;
   contestTitle?: string;
   poolParticipantCount?: number;
   listStakersCount?: number | null;
@@ -87,8 +98,18 @@ function peerDisplayName(label: string, address: string): string {
  * the contest is off-chain or no overlap exists, the section is hidden or
  * clearly labelled when missing so nothing is fabricated.
  */
+function formatDeckTrust(stakeBase: number, units: number): string {
+  if (stakeBase <= 0 || units < 1) return '—';
+  const t = stakeBase * units;
+  if (t >= 100) return `${Math.round(t)}`;
+  const rounded = Math.round(t * 100) / 100;
+  return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(2).replace(/\.?0+$/, '');
+}
+
 export const ArenaCompareView: React.FC<Props> = ({
   deck,
+  rankTrustUnits = {},
+  stakeBaseLabel = '0.1',
   listCategory,
   peers,
   peersLoading,
@@ -106,13 +127,27 @@ export const ArenaCompareView: React.FC<Props> = ({
   onPickNextGame,
   onOpenConvictionCart,
   onOpenSignal,
+  gameActionsOnly = false,
   contestTitle,
   poolParticipantCount,
   listStakersCount,
   listStakersLoading,
 }) => {
   const palette = useMemo(() => deckPalette(listCategory), [listCategory]);
-  const topFive = deck.slice(0, 5);
+  const stakeBase = useMemo(() => parseStakeBaseLabel(stakeBaseLabel), [stakeBaseLabel]);
+  const myDeckRows = useMemo(
+    () =>
+      deck.map((item, i) => {
+        const units = Math.max(1, rankTrustUnits[item.id] ?? 1);
+        return {
+          rank: i + 1,
+          item,
+          units,
+          trustLabel: formatDeckTrust(stakeBase, units),
+        };
+      }),
+    [deck, rankTrustUnits, stakeBase],
+  );
   const totalPeers = peers.length;
   const topPeer = peers[0] ?? null;
 
@@ -137,167 +172,155 @@ export const ArenaCompareView: React.FC<Props> = ({
       maxWidthClass="max-w-none"
       innerPaddingClassName="px-3 py-5 sm:px-4 sm:py-6 md:px-5 md:py-7 lg:px-6 xl:px-8"
     >
-      {/* HEADER */}
-      <div className="flex flex-col gap-3">
+      {/* ── Page hero ─────────────────────────────────────── */}
+      <header
+        className="rounded-2xl border border-white/[0.08] px-4 py-5 sm:px-6 sm:py-6"
+        style={{
+          background: `linear-gradient(135deg, ${palette.hex}0a 0%, #05070c 55%, #05070c 100%)`,
+          boxShadow: ARENA_SHADOWS.cardResting,
+        }}
+      >
         <p
           className="font-mono text-[10px] font-black uppercase tracking-[0.32em]"
           style={{ color: palette.hex }}
         >
           Step 3 · Compare · {palette.label}
         </p>
-        <h2 className="font-display text-2xl font-black leading-tight tracking-tight text-white sm:text-3xl md:text-[2rem]">
+        <h1 className="mt-2 font-display text-2xl font-black leading-[1.05] tracking-tight text-white sm:text-3xl">
           Your deck vs the board
-        </h2>
+        </h1>
         {contestTitle ? (
-          <div
-            className="rounded-2xl border border-white/[0.08] bg-[#05070c]/80 px-4 py-3 sm:px-5"
-            style={{ boxShadow: ARENA_SHADOWS.cardResting }}
-          >
-            <p className="font-mono text-[9px] font-black uppercase tracking-[0.28em] text-slate-500">Contest</p>
-            <p className="mt-1 font-display text-lg font-black text-white">{contestTitle}</p>
-            <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-slate-400">
+          <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
+            <div className="min-w-0">
+              <p className="font-mono text-[9px] font-black uppercase tracking-[0.24em] text-slate-500">
+                Contest
+              </p>
+              <p className="mt-0.5 truncate font-display text-lg font-black text-white sm:text-xl">
+                {contestTitle}
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
               {typeof poolParticipantCount === 'number' ? (
-                <span className="inline-flex items-center gap-1.5 tabular-nums">
+                <span
+                  className="inline-flex items-center gap-1.5 rounded-lg border border-white/[0.08] bg-black/40 px-2.5 py-1.5 font-mono text-[10px] font-bold uppercase tracking-wider text-slate-300 tabular-nums"
+                >
                   <Users className="h-3.5 w-3.5 opacity-70" aria-hidden />
-                  Pool · {poolParticipantCount} pick{poolParticipantCount === 1 ? '' : 's'}
+                  {poolParticipantCount} pick{poolParticipantCount === 1 ? '' : 's'}
                 </span>
               ) : null}
               {(listStakersLoading || listStakersCount != null) && (
-                <span className="tabular-nums text-slate-500">
+                <span className="inline-flex items-center rounded-lg border border-white/[0.08] bg-black/40 px-2.5 py-1.5 font-mono text-[10px] font-bold uppercase tracking-wider text-slate-500 tabular-nums">
                   {listStakersLoading
-                    ? 'On-chain rankers …'
+                    ? 'Rankers …'
                     : listStakersCount != null &&
-                      `${listStakersCount.toLocaleString()} wallet${listStakersCount === 1 ? '' : 's'} ranked (approx.)`}
+                      `${listStakersCount} wallet${listStakersCount === 1 ? '' : 's'}`}
                 </span>
               )}
             </div>
           </div>
         ) : null}
-        <p className="max-w-2xl text-[13px] leading-relaxed text-slate-400">
-          {listIsOnChain
-            ? 'Every peer here actually staked on this list on-chain. Similarity uses those real picks, not guesses.'
-            : 'This contest isn’t on-chain yet, so we can’t pair you with verified rankers. Numbers shown below are scoped to your own deck only.'}
-        </p>
-        <p className="max-w-2xl text-[12px] leading-relaxed text-slate-500 border-l-2 border-white/[0.08] pl-3">
-          <span className="font-semibold text-slate-400">Your own ranks</span> land in the success receipt after you sign. See every signed list (ordered, yes/no) under{' '}
-          <Link
-            to="/portfolio#arena-rankings"
-            className="font-semibold text-cyan-300/90 underline decoration-cyan-400/40 underline-offset-2 hover:text-cyan-200"
-          >
-            Portfolio → My ranked lists
-          </Link>
-          , or skim the live feed in{' '}
-          <Link to="/climb?view=explorer" className="font-semibold text-cyan-300/90 underline decoration-cyan-400/40 underline-offset-2 hover:text-cyan-200">
-            Climb → Explorer
-          </Link>
-          .{' '}
-          <span className="text-slate-500">
-            Closest rankers compares your deck to others who have indexed stakes on this list (not only global leaderboard).
-            Similarity stays empty until someone else overlaps your picks. After you sign, wait for the indexer or refresh Compare.
-          </span>
-        </p>
-      </div>
+      </header>
 
-      {/* 2-COLUMN COMPOSITION */}
-      <div className="mt-6 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1fr)_340px] lg:gap-7">
-        {/* ============================ LEFT COLUMN: DECK + PEERS ============================ */}
-        <div className="flex min-w-0 flex-col gap-5">
-          {/* ── Your top-5 mini deck preview ─────────────────── */}
+      {/* ── Main: your deck once + closest rankings + stats rail ─ */}
+      <div className="mt-6 grid grid-cols-1 items-start gap-6 xl:grid-cols-[minmax(0,1fr)_min(100%,300px)] xl:gap-8">
+        <section
+          aria-labelledby="compare-closest-rankings"
+          className="min-w-0 overflow-hidden rounded-2xl border-2"
+          style={{
+            background: `linear-gradient(168deg, ${palette.hex}14 0%, ${ARENA_CARD_SURFACE.bodyBg} 36%, #030508 100%)`,
+            borderColor: palette.line,
+            boxShadow: `${ARENA_SHADOWS.cardLifted}, 0 0 64px ${palette.hex}20`,
+          }}
+        >
           <div
-            className="rounded-2xl border p-5"
-            style={{
-              background: ARENA_CARD_SURFACE.bodyBg,
-              borderColor: palette.line,
-              boxShadow: ARENA_SHADOWS.cardResting,
-            }}
+            className="flex flex-wrap items-end justify-between gap-3 border-b px-4 py-5 sm:px-6"
+            style={{ borderColor: `${palette.hex}40`, background: `${palette.hex}0c` }}
           >
-            <div className="flex items-baseline justify-between">
-              <p
-                className="font-mono text-[10px] font-black uppercase tracking-[0.22em]"
-                style={{ color: palette.hex }}
+            <div className="min-w-0">
+              <h2
+                id="compare-closest-rankings"
+                className="font-display text-[1.65rem] font-black uppercase leading-[0.95] tracking-tight sm:text-4xl"
+                style={{ color: palette.hex, textShadow: `0 0 40px ${palette.hex}55` }}
               >
-                Your top {Math.min(5, topFive.length)}
+                Closest Rankings
+              </h2>
+              <p className="mt-1.5 text-[12px] text-slate-400">
+                Compare peers to <span className="font-semibold text-slate-200">your ranked deck</span> below.
               </p>
-              <span className="font-mono text-[9px] font-bold uppercase tracking-widest text-slate-600">
-                {deck.length} total
-              </span>
             </div>
-            {topFive.length === 0 ? (
-              <p className="mt-3 text-[12px] italic text-slate-500">
-                You haven’t ranked any cards yet. Go back to Rank to build a deck.
-              </p>
+            <span
+              className="inline-flex shrink-0 items-center rounded-xl border-2 px-3.5 py-2 font-display text-sm font-black uppercase tabular-nums"
+              style={{ borderColor: palette.hex, background: palette.hex, color: '#fff' }}
+            >
+              {peersLoading ? '…' : totalPeers} {peersLoading ? '' : totalPeers === 1 ? 'match' : 'matches'}
+            </span>
+          </div>
+
+          {/* Your deck — shown once, with TRUST per pick */}
+          <div
+            className="border-b px-4 py-4 sm:px-6"
+            style={{ borderColor: 'rgba(255,255,255,0.06)' }}
+            aria-labelledby="compare-your-deck"
+          >
+            <h3
+              id="compare-your-deck"
+              className="font-mono text-xs font-black uppercase tracking-[0.2em] text-white"
+            >
+              Your ranked deck
+            </h3>
+            {myDeckRows.length === 0 ? (
+              <p className="mt-2 text-[13px] font-medium text-slate-400">No picks yet — go back to Rank.</p>
             ) : (
-              <ul className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2">
-                {topFive.map((c, i) => (
+              <ol className="mt-3 space-y-2">
+                {myDeckRows.map((row) => (
                   <li
-                    key={c.id}
-                    className="flex items-center gap-3 rounded-xl border border-white/[0.06] bg-white/[0.02] px-3 py-2.5"
+                    key={row.item.id}
+                    className="flex items-center gap-3 rounded-xl border border-white/[0.12] bg-black/40 px-3 py-3 sm:px-4"
                   >
                     <span
-                      className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md font-display text-base font-black tabular-nums"
-                      style={{ background: palette.soft, color: palette.hex }}
+                      className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg border border-white/[0.1] font-display text-lg font-black tabular-nums text-white"
+                      style={{ background: 'rgba(255,255,255,0.1)' }}
                     >
-                      {i + 1}
+                      {row.rank}
                     </span>
-                    <div className="min-w-0 flex-1">
-                      <p className="truncate text-[12px] font-semibold text-slate-100">{c.label}</p>
-                      {c.subtitle ? (
-                        <p className="truncate text-[10px] text-slate-500">{c.subtitle}</p>
-                      ) : null}
-                    </div>
                     <ArenaPortraitImg
-                      src={c.image}
+                      src={row.item.image}
+                      className="h-10 w-10 shrink-0 rounded-md object-cover"
                       loading="lazy"
-                      className="h-9 w-9 shrink-0 rounded-md object-cover"
                     />
+                    <span className="min-w-0 flex-1 truncate text-[15px] font-bold text-white">
+                      {row.item.label}
+                    </span>
+                    <span
+                      className="shrink-0 text-right font-mono text-base font-black tabular-nums leading-none text-white sm:text-lg"
+                      title="TRUST staked on this pick"
+                    >
+                      {row.trustLabel}
+                      <span className="ml-1 text-sm font-black text-white/90">{CURRENCY_SYMBOL}</span>
+                    </span>
                   </li>
                 ))}
-              </ul>
+              </ol>
             )}
           </div>
 
-          {/* ── Peer comparison list ─────────────────────────── */}
-          <div
-            className="rounded-2xl border"
-            style={{
-              background: ARENA_CARD_SURFACE.bodyBg,
-              borderColor: ARENA_CARD_SURFACE.edgeMuted,
-              boxShadow: ARENA_SHADOWS.cardResting,
-            }}
-          >
-            <div className="flex items-baseline justify-between border-b border-white/[0.05] px-5 py-4">
-              <div>
-                <p
-                  className="font-mono text-[10px] font-black uppercase tracking-[0.22em]"
-                  style={{ color: palette.hex }}
-                >
-                  Closest rankers
-                </p>
-                <p className="mt-1 text-[12px] text-slate-400">
-                  {listIsOnChain
-                    ? 'Players on the live leaderboard, sorted by real overlap with your deck.'
-                    : 'Available once this contest mints on-chain.'}
-                </p>
-              </div>
-              <span className="font-mono text-[9px] font-bold uppercase tracking-widest text-slate-600">
-                {peersLoading ? 'syncing' : `${totalPeers} match${totalPeers === 1 ? '' : 'es'}`}
-              </span>
-            </div>
+          <PeerList
+            myDeckRows={myDeckRows}
+            listIsOnChain={listIsOnChain}
+            peersLoading={peersLoading}
+            peers={peers}
+            palette={palette}
+            pendingStakeCount={pendingStakeCount}
+            batchMode={batchMode}
+            isWalletConnected={isWalletConnected}
+          />
+        </section>
 
-            <PeerList
-              listIsOnChain={listIsOnChain}
-              peersLoading={peersLoading}
-              peers={peers}
-              palette={palette}
-              pendingStakeCount={pendingStakeCount}
-              batchMode={batchMode}
-              isWalletConnected={isWalletConnected}
-            />
-          </div>
-        </div>
-
-        {/* ============================ RIGHT COLUMN: SUMMARY ============================ */}
-        <aside className="flex min-w-0 flex-col gap-4">
+        {/* Stats rail */}
+        <aside className="flex min-w-0 flex-col gap-4 xl:sticky xl:top-4">
+          <p className="font-mono text-[10px] font-black uppercase tracking-[0.22em] text-slate-500 px-0.5">
+            At a glance
+          </p>
           {/* 1) SIMILARITY HEADLINE */}
           <div
             className="rounded-2xl border p-5"
@@ -321,12 +344,8 @@ export const ArenaCompareView: React.FC<Props> = ({
                 <p className="font-display text-2xl font-black tracking-tight text-slate-400">No data yet</p>
                 <p className="mt-2 text-[11px] leading-relaxed text-slate-500">
                   {listIsOnChain
-                    ? batchMode && pendingStakeCount < 1
-                      ? 'Overlap needs another wallet with indexed YES/NO stakes that match subjects in your deck. Right after you sign it can stay empty until the subgraph updates and someone else ranks overlapping picks.'
-                      : batchMode && pendingStakeCount > 0
-                        ? 'After you sign your queued deposits, similarities can populate as peers appear on-chain.'
-                        : 'No overlapping rankers yet. Keep playing or check back after indexer sync.'
-                    : 'Mint this contest on-chain to unlock real comparison vs other players.'}
+                    ? 'Shows when another wallet overlaps your deck on this list.'
+                    : 'Mint on-chain to unlock peer similarity.'}
                 </p>
               </div>
             ) : (
@@ -423,11 +442,45 @@ export const ArenaCompareView: React.FC<Props> = ({
             className="flex flex-col gap-2.5 rounded-2xl border p-4"
             style={{
               background: ARENA_CARD_SURFACE.bodyBg,
-              borderColor: hasPendingWrites ? palette.line : ARENA_CARD_SURFACE.edgeMuted,
+              borderColor: gameActionsOnly ? ARENA_CARD_SURFACE.edgeMuted : hasPendingWrites ? palette.line : ARENA_CARD_SURFACE.edgeMuted,
             }}
           >
-            {/* Queued writes preview when something is ready to commit */}
-            {queuedChainItems.length > 0 ? (
+            {gameActionsOnly ? (
+              <>
+                <p className="text-[11px] leading-snug text-slate-400">
+                  Contest is live on-chain. Pick your next game when you are ready.
+                </p>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      playArenaUiClick();
+                      onRandomGame();
+                    }}
+                    onMouseEnter={() => playArenaUiHover()}
+                    className="inline-flex min-h-[48px] flex-1 items-center justify-center gap-2 rounded-xl border border-white/12 bg-black/30 px-3 py-3 text-[10px] font-bold uppercase tracking-wider text-slate-200 transition-colors hover:bg-white/[0.04] hover:text-white"
+                  >
+                    <Shuffle className="h-3.5 w-3.5 shrink-0 opacity-80" strokeWidth={2.2} aria-hidden />
+                    Play random game
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      playArenaUiClick();
+                      onPickNextGame();
+                    }}
+                    onMouseEnter={() => playArenaUiHover()}
+                    className="inline-flex min-h-[48px] flex-1 items-center justify-center gap-2 rounded-xl px-3 py-3 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-slate-900 transition-colors hover:brightness-110 active:scale-[0.99]"
+                    style={{ background: palette.hex }}
+                  >
+                    <Sparkles className="h-3.5 w-3.5 shrink-0 opacity-90" strokeWidth={2.2} aria-hidden />
+                    Choose new game
+                  </button>
+                </div>
+              </>
+            ) : null}
+
+            {!gameActionsOnly && queuedChainItems.length > 0 ? (
               <div
                 className="mb-1 rounded-xl border px-3 py-2.5"
                 style={{ borderColor: palette.line, background: palette.soft }}
@@ -459,7 +512,7 @@ export const ArenaCompareView: React.FC<Props> = ({
               </div>
             ) : null}
 
-            {sessionDeckNote ? (
+            {!gameActionsOnly && sessionDeckNote ? (
               <div className="mb-1 rounded-xl border border-white/[0.08] bg-black/30 px-3 py-2.5">
                 <p className="font-mono text-[9px] font-black uppercase tracking-[0.22em] text-slate-500">
                   Session deck
@@ -468,8 +521,7 @@ export const ArenaCompareView: React.FC<Props> = ({
               </div>
             ) : null}
 
-            {/* Honest explanation when Compare would otherwise imply a Sign that isn’t surfaced */}
-            {listIsOnChain && batchMode && !hasPendingWrites && !pendingPromote ? (
+            {!gameActionsOnly && listIsOnChain && batchMode && !hasPendingWrites && !pendingPromote ? (
               <div className="mb-1 rounded-xl border border-white/[0.08] bg-black/25 px-3 py-2.5">
                 <p className="text-[11px] leading-snug text-slate-400">
                   <span className="font-semibold text-slate-200">Signing</span> runs from{' '}
@@ -479,7 +531,7 @@ export const ArenaCompareView: React.FC<Props> = ({
               </div>
             ) : null}
 
-            {/* Primary CTA: sign when needed, otherwise pick another game */}
+            {!gameActionsOnly ? (
             <button
               type="button"
               onClick={() => {
@@ -503,27 +555,44 @@ export const ArenaCompareView: React.FC<Props> = ({
               ) : (
                 <>
                   <Sparkles className="h-4 w-4" strokeWidth={2.4} aria-hidden />
-                  Pick my next game
+                  Choose new game
                 </>
               )}
               <ArrowRight size={14} strokeWidth={2.6} className="transition-transform group-hover:translate-x-0.5" />
             </button>
+            ) : null}
 
-            {/* Optional escape hatch when something is queued */}
-            {hasPendingWrites ? (
+            {!gameActionsOnly ? (
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  playArenaUiClick();
+                  onRandomGame();
+                }}
+                onMouseEnter={() => playArenaUiHover()}
+                className={`inline-flex min-h-[44px] flex-1 items-center justify-center gap-2 rounded-xl border border-white/12 bg-black/30 px-3 py-2.5 text-[10px] font-bold uppercase tracking-wider text-slate-200 transition-colors hover:bg-white/[0.04] hover:text-white`}
+              >
+                <Shuffle className="h-3.5 w-3.5 shrink-0 opacity-80" strokeWidth={2.2} aria-hidden />
+                Play random game
+              </button>
               <button
                 type="button"
                 onClick={() => {
                   playArenaUiClick();
                   onPickNextGame();
                 }}
-                className="w-full py-1 text-center text-[10px] font-bold uppercase tracking-wider text-slate-500 underline-offset-2 hover:text-slate-300 hover:underline"
+                onMouseEnter={() => playArenaUiHover()}
+                className="inline-flex min-h-[44px] flex-1 items-center justify-center gap-2 rounded-xl border border-white/[0.08] px-3 py-2.5 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-slate-300 transition-colors hover:bg-white/[0.04] hover:text-white"
+                style={{ background: palette.soft }}
               >
-                Skip without signing (next game)
+                <Sparkles className="h-3.5 w-3.5 shrink-0 opacity-80" strokeWidth={2.2} aria-hidden />
+                Choose new game
               </button>
+            </div>
             ) : null}
 
-            {batchMode && onOpenConvictionCart && !hasPendingWrites ? (
+            {!gameActionsOnly && batchMode && onOpenConvictionCart && !hasPendingWrites ? (
               <button
                 type="button"
                 onClick={() => {
@@ -543,35 +612,21 @@ export const ArenaCompareView: React.FC<Props> = ({
               </button>
             ) : null}
 
-            <div className="flex gap-2">
+            {!gameActionsOnly && onOpenSignal ? (
               <button
                 type="button"
                 onClick={() => {
                   playArenaUiClick();
-                  onRandomGame();
+                  onOpenSignal();
                 }}
                 onMouseEnter={() => playArenaUiHover()}
-                className={`inline-flex min-h-[44px] items-center justify-center gap-2 rounded-xl border border-white/12 bg-black/30 px-3 py-2.5 text-[10px] font-bold uppercase tracking-wider text-slate-200 transition-colors hover:bg-white/[0.04] hover:text-white ${onOpenSignal ? 'flex-1' : 'w-full'}`}
+                className="inline-flex min-h-[40px] w-full items-center justify-center gap-2 rounded-xl border border-white/[0.08] px-3 py-2 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-slate-400 transition-colors hover:bg-white/[0.04] hover:text-white"
+                style={{ background: palette.soft }}
               >
-                <Shuffle className="h-3.5 w-3.5 shrink-0 opacity-80" strokeWidth={2.2} aria-hidden />
-                Random
+                <Radio className="h-3.5 w-3.5 shrink-0 opacity-80" strokeWidth={2.2} aria-hidden />
+                Open Signal
               </button>
-              {onOpenSignal ? (
-                <button
-                  type="button"
-                  onClick={() => {
-                    playArenaUiClick();
-                    onOpenSignal();
-                  }}
-                  onMouseEnter={() => playArenaUiHover()}
-                  className="flex min-h-[44px] flex-1 items-center justify-center gap-2 rounded-xl border border-white/[0.08] px-3 py-2.5 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-slate-400 transition-colors hover:bg-white/[0.04] hover:text-white"
-                  style={{ background: palette.soft }}
-                >
-                  <Radio className="h-3.5 w-3.5 shrink-0 opacity-80" strokeWidth={2.2} aria-hidden />
-                  Signal
-                </button>
-              ) : null}
-            </div>
+            ) : null}
           </div>
         </aside>
       </div>
@@ -579,9 +634,183 @@ export const ArenaCompareView: React.FC<Props> = ({
   );
 };
 
+/* ============================== Compare helpers ============================== */
+
+type MyDeckRow = {
+  rank: number;
+  item: RankItem;
+  units: number;
+  trustLabel: string;
+};
+
+type DeckCompareRow = {
+  id: string;
+  label: string;
+  image?: string;
+  myRank: number | null;
+  myTrust: string;
+  theirRank: number | null;
+  theirTrust: string;
+  theirSupport: boolean | null;
+  verdict: 'same-rank' | 'agree' | 'pass' | 'you-only' | 'them-only';
+};
+
+function buildDeckCompareRows(
+  myDeckRows: MyDeckRow[],
+  peer: ArenaComparePeer,
+): DeckCompareRow[] {
+  const myById = new Map<string, { rank: number; label: string; image?: string; trust: string }>();
+  for (const row of myDeckRows) {
+    myById.set(row.item.id.toLowerCase(), {
+      rank: row.rank,
+      label: row.item.label,
+      image: row.item.image,
+      trust: row.trustLabel,
+    });
+  }
+
+  const theirById = new Map<string, PortalListRankRow>();
+  for (const r of peer.listRanking) {
+    theirById.set(r.subjectId.toLowerCase(), r);
+  }
+
+  const supportById = new Map<string, boolean>();
+  for (const s of peer.similarity.sharedSubjects) {
+    supportById.set(s.id.toLowerCase(), s.theirSupport);
+  }
+  for (const c of peer.claims) {
+    const k = c.subjectId.toLowerCase();
+    if (!supportById.has(k)) supportById.set(k, c.support);
+  }
+
+  const rows: DeckCompareRow[] = [];
+  const ids = new Set([...myById.keys(), ...theirById.keys()]);
+
+  for (const id of ids) {
+    const mine = myById.get(id);
+    const theirs = theirById.get(id);
+    const theirSupport = supportById.get(id) ?? theirs?.support ?? null;
+
+    let verdict: DeckCompareRow['verdict'];
+    if (mine && theirs) {
+      if (theirSupport === false) verdict = 'pass';
+      else if (mine.rank === theirs.rank) verdict = 'same-rank';
+      else verdict = 'agree';
+    } else if (mine) verdict = 'you-only';
+    else verdict = 'them-only';
+
+    rows.push({
+      id,
+      label: mine?.label ?? theirs?.label ?? 'Pick',
+      image: mine?.image ?? theirs?.image,
+      myRank: mine?.rank ?? null,
+      myTrust: mine?.trust ?? '—',
+      theirRank: theirs?.rank ?? null,
+      theirTrust: theirs?.trustLabel ?? '—',
+      theirSupport,
+      verdict,
+    });
+  }
+
+  return rows.sort((a, b) => {
+    const order = (r: DeckCompareRow) => {
+      if (r.myRank != null && r.theirRank != null) return r.myRank;
+      if (r.myRank != null) return r.myRank + 50;
+      return (r.theirRank ?? 99) + 100;
+    };
+    return order(a) - order(b);
+  });
+}
+
+function verdictChip(
+  verdict: DeckCompareRow['verdict'],
+  palette: DeckPaletteEntry,
+): { label: string; color: string; bg: string; border: string } {
+  switch (verdict) {
+    case 'same-rank':
+      return {
+        label: 'Same #',
+        color: palette.hex,
+        bg: palette.soft,
+        border: palette.line,
+      };
+    case 'agree':
+      return {
+        label: 'Agree',
+        color: '#34d399',
+        bg: 'rgba(16,185,129,0.1)',
+        border: 'rgba(16,185,129,0.35)',
+      };
+    case 'pass':
+      return {
+        label: 'They passed',
+        color: '#fb7185',
+        bg: 'rgba(255,77,122,0.08)',
+        border: 'rgba(255,77,122,0.35)',
+      };
+    case 'you-only':
+      return {
+        label: 'You only',
+        color: '#94a3b8',
+        bg: 'rgba(148,163,184,0.08)',
+        border: 'rgba(148,163,184,0.25)',
+      };
+    default:
+      return {
+        label: 'Them only',
+        color: '#94a3b8',
+        bg: 'rgba(148,163,184,0.08)',
+        border: 'rgba(148,163,184,0.25)',
+      };
+  }
+}
+
+const RankStakeCell: React.FC<{
+  rank: number;
+  trust: string;
+  variant: 'you' | 'them';
+  palette: DeckPaletteEntry;
+}> = ({ rank, trust, variant, palette }) => {
+  const isYou = variant === 'you';
+  return (
+    <div
+      className="flex min-w-[6rem] flex-col items-center justify-center rounded-xl border-2 px-2.5 py-2.5 tabular-nums sm:min-w-[6.75rem]"
+      style={
+        isYou
+          ? {
+              borderColor: 'rgba(255,255,255,0.2)',
+              background: 'rgba(255,255,255,0.1)',
+              color: '#fff',
+            }
+          : {
+              borderColor: palette.line,
+              background: palette.soft,
+              color: palette.hex,
+              boxShadow: `0 0 16px ${palette.hex}22`,
+            }
+      }
+    >
+      <span className="font-display text-2xl font-black leading-none sm:text-3xl">#{rank}</span>
+      <span
+        className="mt-1 font-mono text-sm font-black leading-none sm:text-base"
+        style={{ color: isYou ? '#ffffff' : palette.hex }}
+      >
+        {trust !== '—' ? (
+          <>
+            {trust} <span className="opacity-90">{CURRENCY_SYMBOL}</span>
+          </>
+        ) : (
+          '—'
+        )}
+      </span>
+    </div>
+  );
+};
+
 /* ============================== Peer List ============================== */
 
 const PeerList: React.FC<{
+  myDeckRows: MyDeckRow[];
   listIsOnChain: boolean;
   peersLoading: boolean;
   peers: ArenaComparePeer[];
@@ -589,7 +818,7 @@ const PeerList: React.FC<{
   pendingStakeCount: number;
   batchMode: boolean;
   isWalletConnected: boolean;
-}> = ({ listIsOnChain, peersLoading, peers, palette, pendingStakeCount, batchMode, isWalletConnected }) => {
+}> = ({ myDeckRows, listIsOnChain, peersLoading, peers, palette, pendingStakeCount, batchMode, isWalletConnected }) => {
   if (!listIsOnChain) {
     return (
       <EmptyState
@@ -610,13 +839,13 @@ const PeerList: React.FC<{
   }
   if (peers.length === 0) {
     const copyQueued =
-      'Queued deposits are live after Sign + pick next game. Overlap scores need YES/NO stakes from other wallets on this list. We scan leaderboard and recent rankers; give the subgraph a short moment after signing.';
+      'Sign your rank stakes first — overlaps appear once other wallets stake on the same picks.';
     const copyNobodyElseOverlap =
-      'We compare your deck to wallets with stakes here (leaderboard + recent rankers). You never sit beside yourself, so this stays quiet until someone overlaps your picks or indexing finishes.';
+      'No overlapping rankers yet. Someone else needs to stake on this list with picks that match yours.';
     const copyDisconnected =
-      'Connect your wallet, then Curate → Agree to queue rank stakes. After you sign from Compare, overlaps can populate here.';
+      'Connect your wallet and finish Rank to see peers here.';
     const copyLegacy =
-      'Closest rankers needs overlapping indexed stakes on this list from real wallets.';
+      'Waiting for another wallet with overlapping stakes on this list.';
 
     let title = 'No overlaps yet';
     let copyPeer = copyLegacy;
@@ -662,90 +891,290 @@ const PeerList: React.FC<{
   return (
     <ul className="divide-y divide-white/[0.05]">
       {peers.map((p, idx) => (
-        <PeerRow key={p.player.address} peer={p} idx={idx} palette={palette} />
+        <PeerRow
+          key={p.player.address}
+          peer={p}
+          idx={idx}
+          palette={palette}
+          myDeckRows={myDeckRows}
+        />
       ))}
     </ul>
   );
 };
 
-const PeerRow: React.FC<{ peer: ArenaComparePeer; idx: number; palette: DeckPaletteEntry }> = ({
-  peer,
-  idx,
-  palette,
-}) => {
-  const { player, similarity } = peer;
+const PeerRow: React.FC<{
+  peer: ArenaComparePeer;
+  idx: number;
+  palette: DeckPaletteEntry;
+  myDeckRows: MyDeckRow[];
+}> = ({ peer, idx, palette, myDeckRows }) => {
+  const reduceMotion = useReducedMotion();
+  const [expanded, setExpanded] = useState(false);
+  const { player, similarity, listRanking } = peer;
   const name = peerDisplayName(player.label, player.address);
   const initial = name.replace(/^0x/, '').slice(0, 1).toUpperCase() || '?';
   const sharedTop = similarity.sharedSubjects.slice(0, 3);
+  const canExpand = listRanking.length > 0 || myDeckRows.length > 0;
+  const compareRows = useMemo(() => buildDeckCompareRows(myDeckRows, peer), [myDeckRows, peer]);
+  const overlapRows = useMemo(
+    () => compareRows.filter((r) => r.myRank != null && r.theirRank != null),
+    [compareRows],
+  );
+  const theirOnlyRows = useMemo(
+    () => compareRows.filter((r) => r.myRank == null && r.theirRank != null),
+    [compareRows],
+  );
 
   return (
-    <li className="flex items-stretch gap-3 px-5 py-4">
-      {/* Rank pill */}
-      <span
-        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md font-display text-sm font-black tabular-nums"
-        style={{ background: palette.soft, color: palette.hex }}
-      >
-        {idx + 1}
-      </span>
+    <li className="border-b border-white/[0.06] last:border-b-0">
+      <div className="flex items-stretch gap-3 px-5 py-4 sm:px-6">
+        <span
+          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg border-2 font-display text-lg font-black tabular-nums"
+          style={{
+            borderColor: palette.line,
+            background: palette.soft,
+            color: palette.hex,
+            boxShadow: `0 0 20px ${palette.hex}28`,
+          }}
+        >
+          {idx + 1}
+        </span>
 
-      {/* Avatar */}
-      <div
-        className="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-xl border bg-[#070a10]"
-        style={{ borderColor: palette.line }}
-      >
-        <ArenaPortraitImg src={player.image} className="h-full w-full object-cover" loading="lazy">
-          <span className="font-display text-base font-black text-slate-400">{initial}</span>
-        </ArenaPortraitImg>
+        <div
+          className="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-xl border-2 bg-[#070a10]"
+          style={{ borderColor: palette.line }}
+        >
+          <ArenaPortraitImg src={player.image} className="h-full w-full object-cover" loading="lazy">
+            <span className="font-display text-base font-black text-slate-400">{initial}</span>
+          </ArenaPortraitImg>
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex items-baseline justify-between gap-2">
+            <p className="truncate text-[16px] font-black text-white">{name}</p>
+            <span
+              className="shrink-0 font-display text-2xl font-black tabular-nums leading-none sm:text-3xl"
+              style={{ color: palette.hex, textShadow: `0 0 24px ${palette.hex}44` }}
+            >
+              {similarity.similarityPct}%
+            </span>
+          </div>
+          <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-xs font-black uppercase tracking-wide text-slate-100 sm:text-sm">
+            <span className="inline-flex items-center gap-1.5 text-emerald-300">
+              <CheckCircle2 className="h-4 w-4" strokeWidth={2.8} aria-hidden />
+              <span className="tabular-nums text-white">{similarity.agreeCount}</span> agree
+            </span>
+            <span className="inline-flex items-center gap-1.5 text-rose-300">
+              <XCircle className="h-4 w-4" strokeWidth={2.8} aria-hidden />
+              <span className="tabular-nums text-white">{similarity.disagreeCount}</span> pass
+            </span>
+            <span className="tabular-nums text-white">
+              {similarity.sharedCount} shared
+            </span>
+          </div>
+          {sharedTop.length > 0 ? (
+            <div className="mt-2 flex flex-wrap items-center gap-1.5">
+              {sharedTop.map((s) => (
+                <span
+                  key={s.id}
+                  className="inline-flex items-center gap-1.5 rounded-md border-2 px-2.5 py-1.5 font-mono text-xs font-black tabular-nums sm:text-sm"
+                  style={{
+                    borderColor: s.theirSupport ? 'rgba(16,185,129,0.45)' : 'rgba(255,77,122,0.45)',
+                    background: s.theirSupport ? 'rgba(16,185,129,0.12)' : 'rgba(255,77,122,0.1)',
+                    color: s.theirSupport ? '#34d399' : '#fb7185',
+                  }}
+                >
+                  <span className="text-white">#{s.myRank}</span>
+                  <span className="max-w-[140px] truncate text-white">{s.label}</span>
+                  {s.theirSupport ? '✓' : '✕'}
+                </span>
+              ))}
+            </div>
+          ) : null}
+        </div>
+
+        {canExpand ? (
+          <button
+            type="button"
+            onClick={() => {
+              playArenaUiClick();
+              setExpanded((v) => !v);
+            }}
+            onMouseEnter={() => playArenaUiHover()}
+            aria-expanded={expanded}
+            aria-label={expanded ? 'Hide comparison' : 'Compare your rank to theirs'}
+            className="mt-1 flex h-11 shrink-0 items-center gap-2 rounded-xl border-2 px-3.5 font-mono text-xs font-black uppercase tracking-[0.12em] transition-colors hover:bg-white/[0.06]"
+            style={{
+              borderColor: expanded ? palette.hex : palette.line,
+              color: palette.hex,
+              background: expanded ? `${palette.hex}18` : palette.soft,
+            }}
+          >
+            {expanded ? 'Close' : 'Compare'}
+            <ChevronDown
+              className={`h-3.5 w-3.5 shrink-0 transition-transform duration-200 ease-out ${
+                expanded ? 'rotate-180' : ''
+              }`}
+              strokeWidth={2.6}
+              aria-hidden
+            />
+          </button>
+        ) : null}
       </div>
 
-      {/* Identity + shared chips */}
-      <div className="min-w-0 flex-1">
-        <div className="flex items-baseline justify-between gap-2">
-          <p className="truncate text-[13px] font-semibold text-slate-100">{name}</p>
-          <span
-            className="shrink-0 font-mono text-[12px] font-black tabular-nums"
-            style={{ color: palette.hex }}
-          >
-            {similarity.similarityPct}%
-          </span>
+      {/**
+       * CSS grid collapse (not Framer `height: auto`) — avoids layout measurement every frame.
+       * Panel content mounts only while open so closed peers stay light on the DOM.
+       */}
+      <div
+        className={
+          reduceMotion
+            ? expanded
+              ? 'block'
+              : 'hidden'
+            : 'grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none'
+        }
+        style={reduceMotion ? undefined : { gridTemplateRows: expanded ? '1fr' : '0fr' }}
+        aria-hidden={!expanded}
+      >
+        <div className="min-h-0 overflow-hidden">
+          {expanded && canExpand ? (
+            <div className="border-t border-white/[0.06] px-4 pb-5 pt-4 sm:px-6">
+              <p className="font-mono text-xs font-black uppercase tracking-[0.18em] text-white sm:text-sm">
+                Side-by-side · you vs {name}
+              </p>
+              <p className="mt-1 text-sm font-medium text-slate-200">
+                Your deck is above — this table only lines up shared picks.
+              </p>
+
+              {overlapRows.length > 0 ? (
+                <div
+                  className="mt-4 overflow-hidden rounded-xl border-2"
+                  style={{ borderColor: `${palette.hex}44`, background: 'rgba(0,0,0,0.5)' }}
+                >
+                  <div
+                    className="grid grid-cols-[minmax(0,1fr)_5.75rem_5.75rem_5.25rem] gap-x-2 gap-y-0 border-b-2 px-3 py-3 font-mono text-xs font-black uppercase tracking-[0.12em] text-white sm:grid-cols-[minmax(0,1fr)_6.5rem_6.5rem_5.5rem] sm:px-4 sm:py-3.5 sm:text-sm"
+                    style={{ borderColor: `${palette.hex}33`, background: `${palette.hex}10` }}
+                  >
+                    <span>Pick</span>
+                    <span className="text-center">You · {CURRENCY_SYMBOL}</span>
+                    <span className="text-center" style={{ color: palette.hex }}>
+                      Them · {CURRENCY_SYMBOL}
+                    </span>
+                    <span className="text-right">Match</span>
+                  </div>
+                  <ul className="divide-y divide-white/[0.08]">
+                    {overlapRows.map((row) => {
+                      const chip = verdictChip(row.verdict, palette);
+                      return (
+                        <li
+                          key={row.id}
+                          className="grid grid-cols-[minmax(0,1fr)_5.75rem_5.75rem_5.25rem] items-center gap-x-2 gap-y-2 px-3 py-3 sm:grid-cols-[minmax(0,1fr)_6.5rem_6.5rem_5.5rem] sm:gap-x-3 sm:px-4 sm:py-3.5"
+                        >
+                          <div className="flex min-w-0 items-center gap-2.5">
+                            <ArenaPortraitImg
+                              src={row.image}
+                              className="h-9 w-9 shrink-0 rounded-md object-cover"
+                              loading="lazy"
+                            />
+                            <span className="truncate text-base font-bold text-white sm:text-lg">{row.label}</span>
+                          </div>
+                          <RankStakeCell
+                            rank={row.myRank!}
+                            trust={row.myTrust}
+                            variant="you"
+                            palette={palette}
+                          />
+                          <RankStakeCell
+                            rank={row.theirRank!}
+                            trust={row.theirTrust}
+                            variant="them"
+                            palette={palette}
+                          />
+                          <span
+                            className="justify-self-end rounded-lg border-2 px-2.5 py-1.5 font-mono text-xs font-black uppercase tracking-wide sm:text-sm"
+                            style={{
+                              color: chip.color,
+                              background: chip.bg,
+                              borderColor: chip.border,
+                            }}
+                          >
+                            {chip.label}
+                          </span>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              ) : (
+                <p className="mt-3 text-[12px] text-slate-500">No shared picks with this wallet yet.</p>
+              )}
+
+              {listRanking.length > 0 ? (
+                <div
+                  className="mt-4 rounded-xl border-2 p-3 sm:p-4"
+                  style={{ borderColor: `${palette.hex}35`, background: `${palette.hex}08` }}
+                >
+                  <p
+                    className="font-mono text-xs font-black uppercase tracking-[0.16em] sm:text-sm"
+                    style={{ color: palette.hex }}
+                  >
+                    {name}&apos;s full ranking on this list
+                  </p>
+                  <p className="mt-1 text-sm font-medium text-slate-100">
+                    Ordered by total {CURRENCY_SYMBOL} per pick (deposits add up if they rank again).
+                  </p>
+                  <ol className="mt-3 space-y-2">
+                    {listRanking.map((row) => (
+                      <li
+                        key={row.subjectId}
+                        className="flex items-center gap-3 rounded-lg border border-white/[0.1] bg-black/35 px-3 py-2.5"
+                      >
+                        <span
+                          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border-2 font-display text-base font-black tabular-nums sm:text-lg"
+                          style={{
+                            borderColor: palette.line,
+                            background: palette.soft,
+                            color: palette.hex,
+                          }}
+                        >
+                          {row.rank}
+                        </span>
+                        <ArenaPortraitImg
+                          src={row.image}
+                          className="h-9 w-9 shrink-0 rounded-md object-cover"
+                          loading="lazy"
+                        />
+                        <span className="min-w-0 flex-1 truncate text-base font-bold text-white sm:text-lg">
+                          {row.label}
+                        </span>
+                        <span className="shrink-0 font-mono text-base font-black tabular-nums text-white sm:text-lg">
+                          {row.trustLabel !== '—' ? (
+                            <>
+                              {row.trustLabel}{' '}
+                              <span className="text-white/90">{CURRENCY_SYMBOL}</span>
+                            </>
+                          ) : (
+                            <span className={`text-sm font-black ${row.support ? 'text-emerald-400' : 'text-rose-400'}`}>
+                              {row.support ? 'Yes' : 'Pass'}
+                            </span>
+                          )}
+                        </span>
+                      </li>
+                    ))}
+                  </ol>
+                  {theirOnlyRows.length > 0 ? (
+                    <p className="mt-3 text-[12px] font-medium text-slate-400">
+                      + {theirOnlyRows.length} pick{theirOnlyRows.length === 1 ? '' : 's'} they ranked that
+                      aren&apos;t in your deck.
+                    </p>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
         </div>
-        <div className="mt-0.5 flex items-center gap-2 font-mono text-[10px] uppercase tracking-wider text-slate-500">
-          <span className="inline-flex items-center gap-1 text-emerald-300">
-            <CheckCircle2 className="h-3 w-3" strokeWidth={2.6} aria-hidden />
-            {similarity.agreeCount} agree
-          </span>
-          <span className="inline-flex items-center gap-1 text-rose-300/85">
-            <XCircle className="h-3 w-3" strokeWidth={2.6} aria-hidden />
-            {similarity.disagreeCount} pass
-          </span>
-          <span className="text-slate-600">
-            {similarity.sharedCount} shared · {player.listsPlayed || 0} lists played
-          </span>
-        </div>
-        {sharedTop.length > 0 ? (
-          <div className="mt-2 flex flex-wrap items-center gap-1.5">
-            {sharedTop.map((s) => (
-              <span
-                key={s.id}
-                className="inline-flex items-center gap-1 rounded-md border px-2 py-1 font-mono text-[10px] font-bold tabular-nums"
-                style={{
-                  borderColor: s.theirSupport ? 'rgba(16,185,129,0.35)' : 'rgba(255,77,122,0.35)',
-                  background: s.theirSupport ? 'rgba(16,185,129,0.08)' : 'rgba(255,77,122,0.06)',
-                  color: s.theirSupport ? '#34d399' : '#fb7185',
-                }}
-              >
-                <span className="text-slate-500">#{s.myRank}</span>
-                <span className="max-w-[140px] truncate text-slate-100">{s.label}</span>
-                {s.theirSupport ? '✓' : '✕'}
-              </span>
-            ))}
-            {similarity.sharedCount > sharedTop.length ? (
-              <span className="font-mono text-[10px] text-slate-600">
-                +{similarity.sharedCount - sharedTop.length} more
-              </span>
-            ) : null}
-          </div>
-        ) : null}
       </div>
     </li>
   );

--- a/components/arenaFlow/ArenaPromoteContestModal.tsx
+++ b/components/arenaFlow/ArenaPromoteContestModal.tsx
@@ -59,6 +59,15 @@ type Props = {
   isWalletConnected?: boolean;
   /** Called once the promote tx succeeds. Caller registers the new portal list. */
   onPromoted: (result: ArenaPromoteListResult) => void;
+  /**
+   * When set (Rank → Publish and compare), runs promote + rank vault deposits in one
+   * click so the wallet always prompts even if list/atoms/triples already exist.
+   */
+  onMintContest?: (input: {
+    wallet: string;
+    depositPerLeg: string;
+    onProgress: (msg: string) => void;
+  }) => Promise<ArenaPromoteListResult>;
 };
 
 const DEFAULT_DEPOSIT_FALLBACK = formatEther(CURVE_OFFSET);
@@ -78,6 +87,7 @@ export const ArenaPromoteContestModal: React.FC<Props> = ({
   walletAddress,
   isWalletConnected,
   onPromoted,
+  onMintContest,
 }) => {
   const palette = useMemo(() => deckPalette(listCategory), [listCategory]);
   const [minDeposit, setMinDeposit] = useState<string>(DEFAULT_DEPOSIT_FALLBACK);
@@ -155,25 +165,27 @@ export const ArenaPromoteContestModal: React.FC<Props> = ({
 
     try {
       setTxStatus('SIGNING');
-      const result = await promoteArenaListOnChain({
-        title: contestTitle,
-        description: contestDescription,
-        items: effectiveItems,
-        wallet: walletAddress,
-        depositPerLeg: minDeposit,
-        onProgress: (m) => {
-          setTxProgress(m);
-          /** Heuristic: bump status as the service moves through phases. */
-          const lower = m.toLowerCase();
-          if (lower.includes('signature') || lower.includes('signing') || lower.includes('awaiting')) {
-            setTxStatus('SIGNING');
-          } else if (lower.includes('broadcast') || lower.includes('total send') || lower.includes('preparing')) {
-            setTxStatus('BROADCASTING');
-          } else if (lower.includes('anchored') || lower.includes('confirmation') || lower.includes('confirming')) {
-            setTxStatus('CONFIRMING');
-          }
-        },
-      });
+      const progress = (m: string) => {
+        setTxProgress(m);
+        const lower = m.toLowerCase();
+        if (lower.includes('signature') || lower.includes('signing') || lower.includes('awaiting')) {
+          setTxStatus('SIGNING');
+        } else if (lower.includes('broadcast') || lower.includes('total send') || lower.includes('preparing')) {
+          setTxStatus('BROADCASTING');
+        } else if (lower.includes('anchored') || lower.includes('confirmation') || lower.includes('confirming')) {
+          setTxStatus('CONFIRMING');
+        }
+      };
+      const result = onMintContest
+        ? await onMintContest({ wallet: walletAddress, depositPerLeg: minDeposit, onProgress: progress })
+        : await promoteArenaListOnChain({
+            title: contestTitle,
+            description: contestDescription,
+            items: effectiveItems,
+            wallet: walletAddress,
+            depositPerLeg: minDeposit,
+            onProgress: progress,
+          });
       markProxyApproved(walletAddress);
       setTxLastHash(result.triplesTxHash);
       setTxStatus('SUCCESS');

--- a/components/arenaFlow/ArenaRankDeck.tsx
+++ b/components/arenaFlow/ArenaRankDeck.tsx
@@ -40,6 +40,8 @@ type Props = {
   reduceMotion?: boolean;
   onReorder: (next: RankItem[]) => void;
   onCompare: () => void;
+  /** Primary sidebar CTA label (e.g. off-chain → Publish and compare). */
+  compareCtaLabel?: string;
   onCreateCard?: () => void;
   onSignSubmit?: () => void;
   signDisabled?: boolean;
@@ -438,6 +440,7 @@ export const ArenaRankDeck: React.FC<Props> = ({
   reduceMotion,
   onReorder,
   onCompare,
+  compareCtaLabel = 'Compare with others',
   onCreateCard,
   onSignSubmit,
   signDisabled,
@@ -752,7 +755,7 @@ export const ArenaRankDeck: React.FC<Props> = ({
               className="group inline-flex items-center justify-center gap-2 rounded-xl px-5 py-3.5 text-[11px] font-black uppercase tracking-[0.14em] shadow-[0_12px_28px_rgba(0,0,0,0.45)] transition-[transform,filter] hover:brightness-110 active:scale-[0.99] disabled:opacity-40"
               style={{ background: deck.hex, color: deck.contrastText }}
             >
-              Compare with others
+              {compareCtaLabel}
               <ArrowRight size={14} strokeWidth={2.6} className="transition-transform group-hover:translate-x-0.5" />
             </button>
             <p className="mt-1 text-center font-mono text-[9px] uppercase tracking-wider text-slate-600">

--- a/pages/Documentation.tsx
+++ b/pages/Documentation.tsx
@@ -331,7 +331,7 @@ const Documentation: React.FC = () => {
     };
   }, [syncActiveFromScroll]);
 
-  /** Scroll docs column (or mobile window) to a section anchor (TOC / deep links). */
+  /** Scroll docs column (or window on mobile) to a section — shared by TOC clicks and deep links (`/documentation#activity-xp`). */
   const applySectionScroll = useCallback((id: string, behavior: ScrollBehavior) => {
     const target = document.getElementById(id);
     if (!target) return false;
@@ -815,9 +815,9 @@ const Documentation: React.FC = () => {
               </p>
               <p>
                 <strong className="text-slate-100 font-semibold">Activity XP</strong> (wallet connected): +{PROTOCOL_XP_SKILL_CHAT}{' '}
-                per assistant reply (daily cap). Signing a Skill-proposed <strong className="text-slate-200">identity mint</strong> adds
+                per assistant reply (daily cap). Signing a Skill-proposed <strong className="text-slate-200">atom</strong> adds
                 up to +{PROTOCOL_XP_SKILL_ATOM}; signing a <strong className="text-slate-200">triple</strong> adds up to +
-                {PROTOCOL_XP_SKILL_TRIPLE}. On-chain payouts scale with your vault deposit (see{' '}
+                {PROTOCOL_XP_SKILL_TRIPLE} — on-chain amounts scale with your vault deposit (see{' '}
                 <Link
                   to="/documentation#activity-xp"
                   className="text-intuition-primary hover:text-intuition-primary/90 underline-offset-2 hover:underline font-medium"
@@ -827,18 +827,19 @@ const Documentation: React.FC = () => {
                 ).
               </p>
               <p>
-                Typical actions include <strong className="text-slate-100 font-semibold">minting identities</strong>,{' '}
-                <strong className="text-slate-100 font-semibold">creating triples</strong> from subject, predicate,
-                and object labels (missing terms can mint in-flow), and{' '}
+                Typical actions include <strong className="text-slate-100 font-semibold">creating atoms</strong> (labels and
+                deposits), <strong className="text-slate-100 font-semibold">creating triples</strong> from subject, predicate,
+                and object labels (missing atoms can be created in the same flow), and{' '}
                 <strong className="text-slate-100 font-semibold">vault deposits</strong> into existing terms. The sidebar
                 shows approximate costs: on the order of <strong className="text-slate-100 font-semibold">~0.15 {CURRENCY_SYMBOL}</strong>{' '}
-                plus your chosen vault deposit for identity mints and triple creation in many configurations; deposit size for
+                plus your chosen vault deposit for atom and triple creation in many configurations; deposit size for
                 staking varies with the curve and pool. First-time flows may ask for{' '}
                 <strong className="text-slate-100 font-semibold">FeeProxy approval</strong> before the protocol accepts your
                 transactions.
               </p>
               <p>
-                <strong className="text-slate-100 font-semibold">Minimum TRUST for Skill JSON:</strong> Any identity or triple mint the agent proposes carries at least{' '}
+                <strong className="text-slate-100 font-semibold">Minimum TRUST for creations via the Skill:</strong> Any atom
+                or triple the Intuition Skill agent proposes uses a vault deposit of at least{' '}
                 <strong className="text-slate-100 font-semibold">0.5 TRUST</strong> ({CURRENCY_SYMBOL}). The JSON field{' '}
                 <code className="text-xs bg-white/5 px-1.5 py-0.5 rounded text-slate-300">depositTrust</code> must be{' '}
                 <code className="text-xs bg-white/5 px-1.5 py-0.5 rounded text-slate-300">&quot;0.5&quot;</code> or higher (that
@@ -1111,7 +1112,7 @@ const Documentation: React.FC = () => {
             <DocSection id="activity-xp" title="How XP works">
               <p>
                 There are <strong className="text-slate-100 font-semibold">two kinds of XP</strong>.{' '}
-                <strong className="text-slate-100 font-semibold">Arena XP</strong> rewards the fast voting ladder on{' '}
+                <strong className="text-slate-100 font-semibold">Arena XP</strong> is what you get from playing the Arena — the fast voting flow on{' '}
                 <code className="text-xs bg-white/5 px-1.5 py-0.5 rounded text-slate-300">/climb</code>.{' '}
                 <strong className="text-slate-100 font-semibold">Activity XP</strong> is extra credit for things you do on-chain (markets, create flows, sending TRUST, Arena vault deposits, and Signal vouch batches). The app adds it when your wallet qualifies; numbers stay in sync with the little hints on each page.
               </p>
@@ -1133,35 +1134,35 @@ const Documentation: React.FC = () => {
                       <td className="px-4 py-3 text-slate-200">Voted in the Arena (Climb)</td>
                       <td className="px-4 py-3 font-mono tabular-nums text-amber-200/95">≥ {ARENA_XP_PER_RANK_PICK}</td>
                       <td className="px-4 py-3 text-slate-500 text-[13px] leading-snug">
-                        Arena XP: not marketplace trading; higher stakes on picks credit more Arena XP when applicable.
+                        Arena XP — not chain trading. You get more when you turn up the stake on your picks.
                       </td>
                     </tr>
                     <tr>
                       <td className="px-4 py-3 text-slate-200">Bought into a market (deposit TRUST)</td>
                       <td className="px-4 py-3 font-mono tabular-nums text-amber-200/95">+{PROTOCOL_XP_MARKET_ACQUIRE}</td>
                       <td className="px-4 py-3 text-slate-500 text-[13px] leading-snug">
-                        Activity XP scales with TRUST deposited on that market buy (dust buys earn less; caps apply).
+                        Activity XP — scales with how much {CURRENCY_SYMBOL} you deposit on that buy. Dust-sized buys earn little or none; big buys earn up to this max.
                       </td>
                     </tr>
                     <tr>
-                      <td className="px-4 py-3 text-slate-200">Minted an identity term</td>
+                      <td className="px-4 py-3 text-slate-200">Created an atom</td>
                       <td className="px-4 py-3 font-mono tabular-nums text-amber-200/95">+{PROTOCOL_XP_CREATE_ATOM}</td>
                       <td className="px-4 py-3 text-slate-500 text-[13px] leading-snug">
-                        Activity XP scales with vault deposit when you mint; protocol minimum alone is usually below the listed max.
+                        Activity XP — scales with your vault deposit on create; protocol minimum alone usually isn’t enough for the full amount.
                       </td>
                     </tr>
                     <tr>
                       <td className="px-4 py-3 text-slate-200">Created a claim (triple)</td>
                       <td className="px-4 py-3 font-mono tabular-nums text-amber-200/95">+{PROTOCOL_XP_CREATE_CLAIM}</td>
                       <td className="px-4 py-3 text-slate-500 text-[13px] leading-snug">
-                        Activity XP scales with vault deposit when you mint a triple; small deposits earn a fraction of this max.
+                        Activity XP — scales with triple deposit; small deposits earn a fraction of this max.
                       </td>
                     </tr>
                     <tr>
                       <td className="px-4 py-3 text-slate-200">Added something to a list</td>
                       <td className="px-4 py-3 font-mono tabular-nums text-amber-200/95">+{PROTOCOL_XP_ADD_TO_LIST}</td>
                       <td className="px-4 py-3 text-slate-500 text-[13px] leading-snug">
-                        Activity XP scales with list-membership deposits (often the protocol floor unless you raise it).
+                        Activity XP — scales with list triple deposit (often the protocol floor unless you raise it).
                       </td>
                     </tr>
                     <tr>
@@ -1176,35 +1177,36 @@ const Documentation: React.FC = () => {
                       <td className="px-4 py-3 text-slate-200">Signal · Vouch batch (FeeProxy createTriples)</td>
                       <td className="px-4 py-3 font-mono tabular-nums text-amber-200/95">+{PROTOCOL_XP_CREATE_CLAIM}</td>
                       <td className="px-4 py-3 text-slate-500 text-[13px] leading-snug">
-                        Activity XP counts like <strong className="text-slate-400 font-semibold">created a claim</strong>. One batched mint can attach several “vouches for” triples; deposits sum before scaling and caps apply.
+                        Activity XP — treated like <strong className="text-slate-400 font-semibold">created a claim</strong>. One transaction can mint several “vouches for” triples; the deposit basis is the{' '}
+                        <strong className="text-slate-400 font-semibold">sum</strong> of per-vouch vault deposits, then the usual create-claim scaling and daily cap apply.
                       </td>
                     </tr>
                     <tr>
                       <td className="px-4 py-3 text-slate-200">Chatted with Skill agent</td>
                       <td className="px-4 py-3 font-mono tabular-nums text-amber-200/95">+{PROTOCOL_XP_SKILL_CHAT}</td>
                       <td className="px-4 py-3 text-slate-500 text-[13px] leading-snug">
-                        Activity XP grants per assistant reply with wallet connected (deduped); daily cap enforced.
+                        Activity XP — each assistant reply while your wallet is connected (deduped per message). Capped per day.
                       </td>
                     </tr>
                     <tr>
-                      <td className="px-4 py-3 text-slate-200">Used Skill for an identity mint (signed)</td>
+                      <td className="px-4 py-3 text-slate-200">Used Skill to create an atom (signed)</td>
                       <td className="px-4 py-3 font-mono tabular-nums text-amber-200/95">+{PROTOCOL_XP_SKILL_ATOM}</td>
                       <td className="px-4 py-3 text-slate-500 text-[13px] leading-snug">
-                        Activity XP scales with deposit on Skill-signed identities; capped separately from generic Create-flow mint XP.
+                        Activity XP — scales with vault deposit on that Skill-signed atom; small deposits earn a fraction of this max. Separate from the generic “Created an atom” row (Create flow).
                       </td>
                     </tr>
                     <tr>
                       <td className="px-4 py-3 text-slate-200">Used Skill to publish a triple (signed)</td>
                       <td className="px-4 py-3 font-mono tabular-nums text-amber-200/95">+{PROTOCOL_XP_SKILL_TRIPLE}</td>
                       <td className="px-4 py-3 text-slate-500 text-[13px] leading-snug">
-                        Activity XP scales with Skill triple deposits from label bundles or FeeProxy paths; tinier stakes earn less before daily caps clip.
+                        Activity XP — scales with the triple deposit (label pipeline or FeeProxy createTriples from Skill). Higher cap than Skill atom; tiny deposits earn little or none.
                       </td>
                     </tr>
                     <tr>
                       <td className="px-4 py-3 text-slate-200">Sent TRUST (wallet to wallet)</td>
                       <td className="px-4 py-3 font-mono tabular-nums text-amber-200/95">+{PROTOCOL_XP_SEND_TRUST}</td>
                       <td className="px-4 py-3 text-slate-500 text-[13px] leading-snug">
-                        Activity XP only if the send is <strong className="text-slate-400 font-semibold">{PROTOCOL_XP_SEND_TRUST_MIN_TRUST_UNITS} TRUST or more</strong> in one transfer. Daily caps still apply. Different from buying market shares.
+                        Activity XP — only if this send is <strong className="text-slate-400 font-semibold">{PROTOCOL_XP_SEND_TRUST_MIN_TRUST_UNITS} TRUST or more</strong> in one go. Daily caps still apply. Not the same as buying market shares.
                       </td>
                     </tr>
                   </tbody>
@@ -1220,7 +1222,7 @@ const Documentation: React.FC = () => {
                   <strong className="text-slate-200">daily ceiling</strong> (UTC midnight) so endless tiny repeats stop paying off.
                 </p>
                 <p className="text-slate-500 text-xs">
-                  Exact floors, reference sizes, and caps live in <code className="bg-white/5 px-1 rounded text-slate-400">constants.ts</code> next to the XP numbers; tune them as the product evolves.
+                  Exact floors, reference sizes, and caps live in <code className="bg-white/5 px-1 rounded text-slate-400">constants.ts</code> next to the XP numbers — tune them as the product evolves.
                 </p>
               </div>
             </DocSection>
@@ -1303,7 +1305,7 @@ const Documentation: React.FC = () => {
 
               <h3 className="text-base font-semibold text-slate-100 mt-8 mb-3 flex items-center gap-2">
                 <Radio className="w-5 h-5 text-cyan-300 shrink-0" aria-hidden />
-                Signal: Pulse &amp; Vouch
+                Signal — Pulse &amp; Vouch
               </h3>
               {ARENA_UI_VISIBLE ? (
                 <>
@@ -1313,12 +1315,12 @@ const Documentation: React.FC = () => {
                     <strong className="text-slate-100 font-semibold">Vouch</strong>.
                   </p>
                   <p>
-                    <strong className="text-slate-100 font-semibold">Pulse</strong> surfaces identity tag cards (third-person predicates like “has tag”, “trusts”, etc.).
+                    <strong className="text-slate-100 font-semibold">Pulse</strong> surfaces identity atoms as <strong className="text-slate-200">tag cards</strong> (third-person predicates like “has tag”, “trusts”, etc.).
                     Tabs group the rail: <strong className="text-slate-200">Hot</strong> is the editorial spotlight;{' '}
-                    <strong className="text-slate-200">Crowd</strong> follows the curated portal order;{' '}
-                    <strong className="text-slate-200">Yours</strong> tracks identities you pin; <strong className="text-slate-200">My stakes</strong> lists triples where your wallet already has a position, with controls to queue the opposite stance{' '}
-                    (new vault deposit through the conviction cart) or redeem from the vault.{' '}
-                    <strong className="text-slate-200">Support</strong> and <strong className="text-slate-200">Oppose</strong> add rows to the local cart; connect to {NETWORK_NAME}, enable the fee proxy when prompted, then submit from the cart footer to write those vault deposits on-chain.
+                    <strong className="text-slate-200">Crowd</strong> is the full curated portal list (same order you configured in the app);{' '}
+                    <strong className="text-slate-200">Yours</strong> is atoms you pin; <strong className="text-slate-200">My stakes</strong> lists every triple where your wallet already has a position, with controls to queue the opposite stance{' '}
+                    (new on-chain deposit via the conviction cart) or unstake from the vault.{' '}
+                    Tapping <strong className="text-slate-200">Support</strong> or <strong className="text-slate-200">Oppose</strong> queues a stance for that vault triple (local queue — no wallet yet). Queued stances are summarized in the footer; the on-chain batch for those stances is still rolling out — until then, plan in Signal and execute larger Arena list batches from the main grid when you need vault deposits and XP.
                   </p>
                   <p>
                     <strong className="text-slate-100 font-semibold">Vouch</strong> is for named identities (e.g. <code className="text-xs bg-white/5 px-1.5 py-0.5 rounded text-slate-300">.eth</code> /{' '}

--- a/pages/RankedList.tsx
+++ b/pages/RankedList.tsx
@@ -34,9 +34,11 @@ import {
   predicateLooksLikeBattlePredicateLoose,
   resolveMetadata,
   registerArenaPortalListTermsForIndexing,
-  fetchUserArenaRankingClaims,
   fetchDistinctRankingCreatorsForPortalList,
-  fetchDistinctReceiversForPortalListFromProxyDeposits,
+  fetchArenaCompareGraphBundle,
+  discoverPortalListRankerReceiversFromDeposits,
+  buildArenaRankingClaimsForReceivers,
+  invalidateProxyArenaRankDepositsCache,
   fetchApproxDistinctPortalListRankerCount,
   fetchArenaLiveAtomsFromGraph,
   countListMembersForObject,
@@ -85,7 +87,9 @@ import { fetchArenaPlayerLeaderboard, inturankLeaderboardTotalXp, type ArenaPlay
 import {
   aggregateSimilarity,
   computeArenaListSimilarity,
+  buildPortalListRankingByAccumulatedTrust,
   type ArenaSimilarityResult,
+  type PortalListRankRow,
 } from '../services/arenaSimilarity';
 import {
   ARENA_BATCH_MODE,
@@ -94,6 +98,7 @@ import {
   ARENA_XP_PER_RANK_PICK,
   BUILT_ON_INTUITION_PORTAL_LIST_OBJECT_TERM_ID,
   CURVE_OFFSET,
+  LIST_PREDICATE_ID,
   LINEAR_CURVE_ID,
   OFFSET_PROGRESSIVE_CURVE_ID,
   PROTOCOL_XP_ARENA_RANK_ADD_TO_LIST_MULT,
@@ -104,10 +109,13 @@ import {
   clearPendingStorage,
   getFirstListIdWithPending,
   getTotalPendingCount,
+  buildArenaRankStakeRows,
   loadAllPendingRowsLive,
   loadPendingForList,
+  remapPendingRowsMemberTermIds,
   savePendingForList,
   type ArenaPendingRow,
+  type ArenaPendingRowWithSource,
 } from '../services/arenaPendingBatch';
 import {
   ARENA_CATEGORY_PILLS,
@@ -148,7 +156,10 @@ import { ArenaCompareView } from '../components/arenaFlow/ArenaCompareView';
 import { ArenaPortraitImg } from '../components/arenaFlow/ArenaPortraitImg';
 import { ArenaPromoteBanner } from '../components/arenaFlow/ArenaPromoteBanner';
 import { ArenaPromoteContestModal } from '../components/arenaFlow/ArenaPromoteContestModal';
-import type { ArenaPromoteListResult } from '../services/arenaPromoteList';
+import {
+  promoteArenaListOnChain,
+  type ArenaPromoteListResult,
+} from '../services/arenaPromoteList';
 import ArenaStarredRail from '../components/ArenaStarredRail';
 import { XpEarnHint } from '../components/XpEarnHint';
 import IntuRankXpBadge from '../components/IntuRankXpBadge';
@@ -174,6 +185,8 @@ export type ArenaComparePeer = {
   player: ArenaPlayerRow;
   claims: UserArenaRankingClaim[];
   similarity: ArenaSimilarityResult;
+  /** Full list order for this peer on this contest (TRUST-weighted). */
+  listRanking: PortalListRankRow[];
 };
 
 export type RankItemKind = 'claim' | 'atom' | 'token';
@@ -1017,7 +1030,7 @@ const RankedList: React.FC = () => {
    * modal's success callback knows to chain into the rank-batch step instead
    * of just navigating away. Stays `'idle'` until the user hits Submit.
    */
-  const [commitPhase, setCommitPhase] = useState<'idle' | 'promote' | 'rank-batch'>('idle');
+  const [commitPhase, setCommitPhase] = useState<'idle' | 'promote' | 'rank-publish' | 'rank-batch'>('idle');
   /** Per ranked card: TRUST weight = session preset × units (batch rows). */
   const [rankTrustUnits, setRankTrustUnits] = useState<Record<string, number>>({});
   /** Tracks latest trust units for reorder handlers (avoid nested setState drift). */
@@ -1030,6 +1043,9 @@ const RankedList: React.FC = () => {
   const bumpDeckEngagement = useCallback(() => setDeckEngagementTuneCount((c) => c + 1), []);
   const curateInitForListRef = useRef<string | null>(null);
   const prevListIdForFlowRef = useRef<string | null>(null);
+  /** After promote, `listId` changes static → portal; skip the curate reset in the listId effect. */
+  const portalPromoteLandingRef = useRef<string | null>(null);
+  const submitArenaBatchRef = useRef<(() => Promise<void>) | null>(null);
   const guestCurateNudgeRef = useRef(false);
   /** Deeplink vs hub: avoid double-playing the floor-enter stinger for the same list. */
   const arenaFloorStingerPlayedForListRef = useRef<string | null>(null);
@@ -1197,6 +1213,7 @@ const RankedList: React.FC = () => {
 
   useEffect(() => {
     const bump = () => {
+      invalidateProxyArenaRankDepositsCache();
       setComparePeersVersion((v) => v + 1);
       setListRankersTick((t) => t + 1);
     };
@@ -1407,26 +1424,35 @@ const RankedList: React.FC = () => {
         .slice(0, 8)
         .map((p) => p.address);
 
+      const listTermId = activeList.listObjectTermId!;
+
+      let bundle: Awaited<ReturnType<typeof fetchArenaCompareGraphBundle>> | null = null;
       let fromList: string[] = [];
       try {
-        fromList = await fetchDistinctRankingCreatorsForPortalList(
-          activeList.listObjectTermId!,
-          address,
-          20,
-        );
+        const [graphBundle, listCreators] = await Promise.all([
+          fetchArenaCompareGraphBundle(),
+          fetchDistinctRankingCreatorsForPortalList(listTermId, address, 20),
+        ]);
+        if (cancelled) return;
+        bundle = graphBundle;
+        fromList = listCreators;
       } catch (e) {
-        console.warn('[comparePeers] list rankers fetch failed', e);
+        console.warn('[comparePeers] graph bundle / list rankers failed', e);
       }
 
       let fromDeposits: string[] = [];
-      try {
-        fromDeposits = await fetchDistinctReceiversForPortalListFromProxyDeposits(
-          activeList.listObjectTermId!,
-          address,
-          26,
-        );
-      } catch (e) {
-        console.warn('[comparePeers] deposit list rankers fetch failed', e);
+      if (bundle) {
+        try {
+          fromDeposits = discoverPortalListRankerReceiversFromDeposits(
+            listTermId,
+            address,
+            26,
+            bundle.deposits,
+            bundle.stanceByVault,
+          );
+        } catch (e) {
+          console.warn('[comparePeers] deposit list rankers derive failed', e);
+        }
       }
 
       const merged: string[] = [];
@@ -1439,7 +1465,7 @@ const RankedList: React.FC = () => {
         if (merged.length >= 22) break;
       }
 
-      if (merged.length === 0) {
+      if (merged.length === 0 || !bundle) {
         if (!cancelled) {
           setComparePeers([]);
           setComparePeersLoading(false);
@@ -1447,22 +1473,33 @@ const RankedList: React.FC = () => {
         return;
       }
 
-      const results = await Promise.all(
-        merged.map(async (wallet) => {
-          try {
-            const claims = await fetchUserArenaRankingClaims(wallet);
-            const sim = computeArenaListSimilarity(
-              rankDeckItems,
-              claims,
-              activeList.listObjectTermId,
-            );
-            return { player: syntheticRow(wallet), claims, similarity: sim };
-          } catch (e) {
-            console.warn('[comparePeers] failed for', wallet, e);
-            return { player: syntheticRow(wallet), claims: [] as UserArenaRankingClaim[], similarity: null };
-          }
-        }),
-      );
+      const { deposits: rankDeposits, stanceByVault, allow } = bundle;
+      let claimsByWallet: Map<string, UserArenaRankingClaim[]>;
+      try {
+        claimsByWallet = buildArenaRankingClaimsForReceivers(
+          merged,
+          rankDeposits,
+          stanceByVault,
+          allow,
+        );
+      } catch (e) {
+        console.warn('[comparePeers] batch claims build failed', e);
+        claimsByWallet = new Map();
+      }
+
+      const results = merged.map((wallet) => {
+        const walletKey = wallet.toLowerCase();
+        const claims = claimsByWallet.get(walletKey) ?? [];
+        const sim = computeArenaListSimilarity(rankDeckItems, claims, listTermId);
+        const listRanking = buildPortalListRankingByAccumulatedTrust(
+          wallet,
+          listTermId,
+          claims,
+          rankDeposits,
+          stanceByVault,
+        );
+        return { player: syntheticRow(wallet), claims, similarity: sim, listRanking };
+      });
 
       if (cancelled) return;
       const peers: ArenaComparePeer[] = results
@@ -1746,6 +1783,11 @@ const RankedList: React.FC = () => {
     }
     const prev = prevListIdForFlowRef.current;
     if (prev !== listId) {
+      if (portalPromoteLandingRef.current === listId) {
+        portalPromoteLandingRef.current = null;
+        prevListIdForFlowRef.current = listId;
+        return;
+      }
       if (prev != null) {
         clearPersistedContestFlow(prev);
         setArenaFlowPhase('curate');
@@ -1810,9 +1852,17 @@ const RankedList: React.FC = () => {
     if (!persisted || (persisted.phase !== 'rank' && persisted.phase !== 'compare')) return;
 
     const rebuilt = persisted.rankOrderIds
-      .map((id) => pool.find((x) => x.id === id))
+      .map((id) => {
+        const byId = pool.find((x) => x.id === id);
+        if (byId) return byId;
+        const norm = id.trim().toLowerCase();
+        return pool.find((x) => x.label.trim().toLowerCase() === norm);
+      })
       .filter(Boolean) as RankItem[];
     if (rebuilt.length < 1) {
+      if (persisted.phase === 'compare') {
+        return;
+      }
       clearPersistedContestFlow(listId);
       setArenaFlowPhase('curate');
       curateInitForListRef.current = null;
@@ -1853,7 +1903,9 @@ const RankedList: React.FC = () => {
   }, [searchParams]);
 
   useEffect(() => {
+    if (ARENA_CONTEST_FLOW_V2) return;
     if (!listId || loading) return;
+    if (!openBatchAfterLoad) return;
     setOpenBatchAfterLoad(false);
     if (getTotalPendingCount() > 0) {
       setBatchModalOpen(true);
@@ -1864,25 +1916,6 @@ const RankedList: React.FC = () => {
     if (!listId) return;
     savePendingForList(listId, pendingRows);
   }, [listId, pendingRows]);
-
-  useEffect(() => {
-    const onFabToggle = () => {
-      if (!ARENA_BATCH_MODE) return;
-      if (!listId) {
-        const lid = getFirstListIdWithPending();
-        if (lid && getArenaListById(lid)) {
-          navigate(`/climb?list=${encodeURIComponent(lid)}`, { replace: true });
-          setListId(lid);
-          setOpenBatchAfterLoad(true);
-        }
-        return;
-      }
-      if (getTotalPendingCount() < 1) return;
-      setBatchModalOpen((v) => !v);
-    };
-    window.addEventListener('arena-batch-fab-toggle', onFabToggle as EventListener);
-    return () => window.removeEventListener('arena-batch-fab-toggle', onFabToggle as EventListener);
-  }, [listId, navigate]);
 
   const initScoresForPool = useCallback(
     (items: RankItem[]) => {
@@ -1995,19 +2028,27 @@ const RankedList: React.FC = () => {
     [listId, pool]
   );
 
-  const submitArenaBatch = useCallback(async () => {
-    const rowsToSend = loadAllPendingRowsLive(listId, pendingRows);
-    if (rowsToSend.length === 0) return;
+  type SubmitArenaBatchOpts = {
+    rowsOverride?: ArenaPendingRowWithSource[];
+    portalListObjectTermId?: `0x${string}`;
+    listTitle?: string;
+    onProgress?: (msg: string) => void;
+    skipSuccessModal?: boolean;
+  };
+
+  const submitArenaBatch = useCallback(async (opts?: SubmitArenaBatchOpts): Promise<boolean> => {
+    const rowsToSend = opts?.rowsOverride ?? loadAllPendingRowsLive(listId, pendingRows);
+    if (rowsToSend.length === 0) return false;
     if (!isConnected || !address) {
       toast.error('Connect your wallet to submit your batch.');
-      return;
+      return false;
     }
     let baseWei: bigint;
     try {
       baseWei = parseEther((stakeTRUST || '0').trim() || '0');
     } catch {
       toast.error('Invalid stake amount');
-      return;
+      return false;
     }
     for (const row of rowsToSend) {
       const rowWei = baseWei * BigInt(row.units);
@@ -2017,7 +2058,7 @@ const RankedList: React.FC = () => {
             `Each row deposit is stake × units; one row totals ${formatEther(rowWei)} TRUST (${stakeTRUST}×${row.units}). ` +
             `Raise the stake preset or bump units until every line reaches at least ${PROTOCOL_MIN_CLAIM_DEPOSIT_LABEL}.`
         );
-        return;
+        return false;
       }
     }
     const allSubjectsResolvable = rowsToSend.every(
@@ -2025,7 +2066,7 @@ const RankedList: React.FC = () => {
     );
     if (!allSubjectsResolvable) {
       toast.error('Some rows are missing valid term ids/labels for claim creation.');
-      return;
+      return false;
     }
 
     setStakingTx(true);
@@ -2075,18 +2116,43 @@ const RankedList: React.FC = () => {
       const legacyJobs: Array<{ listRows: typeof rowsToSend; listEntry: ReturnType<typeof getArenaListById> }> =
         [];
 
-      for (const [, lr] of byList) {
-        const listEntry = getArenaListById(lr[0]!.sourceListId);
-        const portalListObjectId =
-          listEntry?.source === 'portal' && TERM_ID_RE.test(listEntry.listObjectTermId)
-            ? listEntry.listObjectTermId
-            : null;
+      if (opts?.rowsOverride && opts.portalListObjectTermId) {
+        const portalListObjectId = opts.portalListObjectTermId;
+        const listEntry = getArenaListById(rowsToSend[0]!.sourceListId);
+        const portalEntry: Extract<ArenaListEntry, { source: 'portal' }> =
+          listEntry?.source === 'portal'
+            ? listEntry
+            : {
+                id: portalListIdFromTermId(portalListObjectId),
+                source: 'portal',
+                listObjectTermId: portalListObjectId,
+                title: opts.listTitle ?? activeList?.title ?? 'Arena contest',
+                description: '',
+                tag: 'Live',
+                arenaCategory: activeList?.arenaCategory ?? 'network',
+                listGlyph: activeList?.listGlyph ?? '◆',
+                totalItems: rowsToSend.length,
+                previewItemsData: [],
+              };
+        portalJobs.push({
+          portalListObjectId,
+          listRows: rowsToSend,
+          listEntry: portalEntry,
+        });
+      } else {
+        for (const [, lr] of byList) {
+          const listEntry = getArenaListById(lr[0]!.sourceListId);
+          const portalListObjectId =
+            listEntry?.source === 'portal' && TERM_ID_RE.test(listEntry.listObjectTermId)
+              ? listEntry.listObjectTermId
+              : null;
 
-        if (portalListObjectId && lr.every((row) => TERM_ID_RE.test(row.item.id))) {
-          if (!listEntry) continue;
-          portalJobs.push({ portalListObjectId, listRows: lr, listEntry });
-        } else {
-          legacyJobs.push({ listRows: lr, listEntry });
+          if (portalListObjectId && lr.every((row) => TERM_ID_RE.test(row.item.id))) {
+            if (!listEntry) continue;
+            portalJobs.push({ portalListObjectId, listRows: lr, listEntry });
+          } else {
+            legacyJobs.push({ listRows: lr, listEntry });
+          }
         }
       }
 
@@ -2104,7 +2170,10 @@ const RankedList: React.FC = () => {
         }
       }
 
-      const progressCb = (m: string) => setSubmitProgress(m);
+      const progressCb = (m: string) => {
+        opts?.onProgress?.(m);
+        setSubmitProgress(m);
+      };
 
       const mergedDepositLegs: { termId: string; assetsWei: bigint }[] = [];
       const depositXpRows: Array<{ rowKey: string; rowWei: bigint }> = [];
@@ -2142,7 +2211,18 @@ const RankedList: React.FC = () => {
         const resolved = await Promise.all(
           listRows.map(async (row) => {
             const rowWei = baseWei * BigInt(row.units);
-            const membershipVault = await getListMembershipTripleTermId(row.item.id, portalListObjectId);
+            let membershipVault = await getListMembershipTripleTermId(row.item.id, portalListObjectId);
+            if (
+              !membershipVault &&
+              TERM_ID_RE.test(row.item.id) &&
+              TERM_ID_RE.test(portalListObjectId)
+            ) {
+              membershipVault = calculateTripleId(
+                row.item.id as `0x${string}`,
+                LIST_PREDICATE_ID as `0x${string}`,
+                portalListObjectId as `0x${string}`,
+              );
+            }
             if (!membershipVault) return { row, rowWei, membershipVault: null, counterShares: 0n };
             const yesVault = membershipVault;
             const noVault = calculateCounterTripleId(yesVault);
@@ -2351,7 +2431,7 @@ const RankedList: React.FC = () => {
       setStakingTx(false);
       setSubmitProgress(null);
     }
-    if (!sent) return;
+    if (!sent) return false;
 
     if (address) {
       recordArenaRankingPicks(address, rowsToSend.length);
@@ -2415,16 +2495,18 @@ const RankedList: React.FC = () => {
       }
       /** Arena XP: fixed pick credit per queued row (matches `arenaPickCreditXp` / indexer attribution). */
       const arenaXpDelta = rowsToSend.length * ARENA_XP_PER_RANK_PICK;
-      setArenaBatchSuccess({
-        itemCount: rowsToSend.length,
-        trustLabel: formatEther(totalWei),
-        themeShort: successThemeShort,
-        contextSuffix: successContextSuffix,
-        ...(humanLine ? { humanLine } : {}),
-        ...(activityXpDelta > 0 ? { activityXpEarned: activityXpDelta } : {}),
-        ...(arenaXpDelta > 0 ? { arenaXpEarned: arenaXpDelta } : {}),
-        ...(xpdnGrantsPerTx.length > 0 ? { xpdnByTx: xpdnGrantsPerTx } : {}),
-      });
+      if (!opts?.skipSuccessModal) {
+        setArenaBatchSuccess({
+          itemCount: rowsToSend.length,
+          trustLabel: formatEther(totalWei),
+          themeShort: successThemeShort,
+          contextSuffix: successContextSuffix,
+          ...(humanLine ? { humanLine } : {}),
+          ...(activityXpDelta > 0 ? { activityXpEarned: activityXpDelta } : {}),
+          ...(arenaXpDelta > 0 ? { arenaXpEarned: arenaXpDelta } : {}),
+          ...(xpdnGrantsPerTx.length > 0 ? { xpdnByTx: xpdnGrantsPerTx } : {}),
+        });
+      }
       void refreshPlayers({ silent: true });
       void refreshArenaXpSelf();
       try {
@@ -2442,10 +2524,38 @@ const RankedList: React.FC = () => {
       toast.success('Claims written on Intuition.');
     }
 
+    const touchedListIds = new Set(rowsToSend.map((r) => r.sourceListId));
+    if (listId) touchedListIds.add(listId);
     clearPendingStorage();
+    for (const lid of touchedListIds) clearPendingForList(lid);
     setPendingRows([]);
     setBatchModalOpen(false);
-  }, [pendingRows, listId, isConnected, address, stakeTRUST, refreshPlayers, refreshArenaXpSelf]);
+    setPendingArenaClear(null);
+    setCommitPhase('idle');
+
+    if (
+      ARENA_CONTEST_FLOW_V2 &&
+      listId &&
+      (arenaFlowPhase === 'curate' || arenaFlowPhase === 'rank' || arenaFlowPhase === 'compare')
+    ) {
+      setArenaFlowPhase('compare');
+    }
+    return true;
+  }, [
+    pendingRows,
+    listId,
+    arenaFlowPhase,
+    activeList,
+    isConnected,
+    address,
+    stakeTRUST,
+    refreshPlayers,
+    refreshArenaXpSelf,
+  ]);
+
+  useEffect(() => {
+    submitArenaBatchRef.current = () => submitArenaBatch();
+  }, [submitArenaBatch]);
 
   const updatePendingUnits = useCallback((sourceListId: string, key: string, units: number) => {
     const rows = loadPendingForList(sourceListId);
@@ -2592,16 +2702,18 @@ const RankedList: React.FC = () => {
 
       if (ARENA_BATCH_MODE) {
         applyLocalYesNo(item, support);
-        if (!ARENA_CONTEST_FLOW_V2 || support) {
-          setPendingRows((prev) => [
-            ...prev,
-            {
-              key: `q-${item.id}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
-              item: rankItemToPendingSnapshot(item),
-              support,
-              units: 1,
-            },
-          ]);
+        if (!ARENA_CONTEST_FLOW_V2) {
+          if (support) {
+            setPendingRows((prev) => [
+              ...prev,
+              {
+                key: `q-${item.id}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+                item: rankItemToPendingSnapshot(item),
+                support,
+                units: 1,
+              },
+            ]);
+          }
         }
         return true;
       }
@@ -2712,7 +2824,7 @@ const RankedList: React.FC = () => {
       const merged = autoDistributeStakeUnitsAlongOrder(next, prevTrust, 1, RANK_TRUST_UNITS_MAX);
       setRankDeckItems(next);
       setRankTrustUnits(merged);
-      if (ARENA_BATCH_MODE && listId) {
+      if (ARENA_BATCH_MODE && listId && !ARENA_CONTEST_FLOW_V2) {
         setPendingRows((prevRows) => alignPendingRowsToDeck(next, prevRows, merged));
       }
       bumpDeckEngagement();
@@ -2821,10 +2933,82 @@ const RankedList: React.FC = () => {
     setBatchModalOpen(true);
   }, [isConnected, address, rankFlowCartCount]);
 
-  const onCompareFromRank = useCallback(() => {
+  /**
+   * Rank sidebar CTA. Off-chain contests open the mint modal first; on success we land on Compare.
+   * Portal lists skip straight to Compare (nothing to publish).
+   */
+  const onPublishAndCompareFromRank = useCallback(() => {
     playArenaUiClick();
+
+    if (!isConnected || !address) {
+      void connectWallet();
+      return;
+    }
+
+    if (activeList && activeList.source !== 'portal') {
+      setCommitPhase('rank-publish');
+      setPromoteContestOpen(true);
+      return;
+    }
+
     setArenaFlowPhase('compare');
-  }, []);
+  }, [activeList, isConnected, address]);
+
+  /**
+   * Rank → Mint: promote contest, then vault-deposit rank stakes in the same wallet
+   * session (so a re-promote with reused atoms still prompts for deposits).
+   */
+  const handleArenaMintContest = useCallback(
+    async ({
+      wallet,
+      depositPerLeg,
+      onProgress,
+    }: {
+      wallet: string;
+      depositPerLeg: string;
+      onProgress: (msg: string) => void;
+    }): Promise<ArenaPromoteListResult> => {
+      const promoteItems = rankDeckItems.map((p) => ({
+        id: p.id,
+        label: p.label,
+        subtitle: p.subtitle,
+        image: p.image,
+      }));
+      const result = await promoteArenaListOnChain({
+        title: activeList?.title ?? 'New contest',
+        description:
+          activeList && 'description' in activeList && activeList.description
+            ? activeList.description
+            : undefined,
+        items: promoteItems,
+        wallet,
+        depositPerLeg,
+        onProgress,
+      });
+      const portalId = portalListIdFromTermId(result.listTermId);
+      const stakeRows = buildArenaRankStakeRows({
+        deck: rankDeckItems,
+        rankTrustUnits,
+        memberTermIds: result.memberTermIds,
+        sourceListId: portalId,
+      });
+      if (stakeRows.length > 0) {
+        onProgress('Confirm rank stakes in your wallet…');
+        const stakesOk = await submitArenaBatch({
+          rowsOverride: stakeRows,
+          portalListObjectTermId: result.listTermId,
+          listTitle: activeList?.title,
+          onProgress,
+          skipSuccessModal: true,
+        });
+        if (!stakesOk) {
+          throw new Error('Rank stake signing did not complete. Your contest is on-chain; try again from Rank.');
+        }
+      }
+      return result;
+    },
+    [activeList, rankDeckItems, rankTrustUnits, submitArenaBatch],
+  );
 
   const onYesNo = (item: RankItem, support: boolean) => {
     if (!round) return;
@@ -2970,7 +3154,7 @@ const RankedList: React.FC = () => {
       return;
     }
 
-    if (ARENA_BATCH_MODE && rankFlowCartCount > 0) {
+    if (!ARENA_CONTEST_FLOW_V2 && ARENA_BATCH_MODE && rankFlowCartCount > 0) {
       setCommitPhase('rank-batch');
       setBatchModalOpen(true);
       return;
@@ -3738,36 +3922,6 @@ const RankedList: React.FC = () => {
                     style={{ color: false ? '#0f172a' : ARENA_THEME.cyanMuted }}
                   />
                 </button>
-                {ARENA_BATCH_MODE && batchModalRows.length > 0 ? (
-                  <>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        playArenaUiClick();
-                        setBatchModalOpen(true);
-                      }}
-                      className={
-                        false
-                          ? 'rounded-xl border border-sky-200 bg-sky-50 px-3 py-2 text-[10px] font-bold uppercase tracking-wide text-sky-900 transition-colors hover:border-sky-300'
-                          : 'rounded-xl border border-cyan-500/35 bg-cyan-500/[0.1] px-3 py-2 text-[10px] font-bold uppercase tracking-wide text-cyan-100 transition-colors hover:border-cyan-400/50'
-                      }
-                    >
-                      Cart ({batchModalRows.length})
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        playArenaUiClick();
-                        setPendingArenaClear((k) => (k === 'cart' ? null : 'cart'));
-                      }}
-                      aria-label="Clear entire conviction cart"
-                      title="Clear all queued stances (every list)"
-                      className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-white/[0.12] bg-black/35 text-slate-400 transition-colors hover:border-rose-500/40 hover:bg-rose-500/10 hover:text-rose-200"
-                    >
-                      <Trash2 size={17} strokeWidth={2.2} aria-hidden />
-                    </button>
-                  </>
-                ) : null}
                 {hasClearableContestPicks ? (
                   <button
                     type="button"
@@ -3947,28 +4101,6 @@ const RankedList: React.FC = () => {
               </div>
             ) : null}
 
-            {ARENA_BATCH_MODE && batchModalRows.length > 0 ? (
-              <button
-                type="button"
-                onClick={() => {
-                  playArenaUiClick();
-                  setBatchModalOpen(true);
-                }}
-                className="mt-3 w-full text-center rounded-xl py-2.5 px-3 border transition-colors hover:border-intuition-primary/45 hover:bg-intuition-primary/[0.08]"
-                style={{
-                  borderColor: `${ARENA_THEME.cyan}44`,
-                  background: `linear-gradient(135deg, ${ARENA_THEME.cyan}10, rgba(8,8,12,0.85))`,
-                  boxShadow: `inset 0 1px 0 rgba(255,255,255,0.06), 0 0 20px ${ARENA_THEME.redDim}`,
-                }}
-              >
-                <span className="block text-[11px] font-bold" style={{ color: ARENA_THEME.cyanMuted }}>
-                  Review conviction cart ({batchModalRows.length} queued)
-                </span>
-                <span className="block text-[9px] text-slate-500 mt-1 font-semibold uppercase tracking-wide">
-                  TRUST settles when you submit the batch
-                </span>
-              </button>
-            ) : null}
           </div>
           )}
 
@@ -4023,14 +4155,18 @@ const RankedList: React.FC = () => {
                   reduceMotion={reduceMotion}
                   onReorder={onRankReorder}
                   onRemoveItem={onRankRemoveItem}
-                  onCompare={onCompareFromRank}
+                  onCompare={onPublishAndCompareFromRank}
+                  compareCtaLabel={
+                    activeList && activeList.source !== 'portal'
+                      ? 'Publish and compare'
+                      : 'Compare with others'
+                  }
                   /**
                    * On-chain writes (list promotion, identity mints, membership
                    * triples, rank stakes) finish in one Compare commit. Rank no longer
                    * shows a sign button (`onSignSubmit` omitted on purpose).
                    */
                   signDisabled={stakingTx}
-                  queuedStanceCount={rankFlowCartCount}
                   listTitle={activeList?.title}
                   poolParticipantCount={pool.length}
                   listStakersCount={portalListRankerCount}
@@ -4044,6 +4180,8 @@ const RankedList: React.FC = () => {
               ) : (
                 <ArenaCompareView
                   deck={rankDeckItems}
+                  rankTrustUnits={rankTrustUnits}
+                  stakeBaseLabel={stakeTRUST}
                   listCategory={activeList?.arenaCategory}
                   peers={comparePeers}
                   peersLoading={comparePeersLoading}
@@ -4053,7 +4191,7 @@ const RankedList: React.FC = () => {
                   gamesToTop10Hint={compareGamesToTop10}
                   pendingPromote={Boolean(activeList && activeList.source !== 'portal')}
                   pendingCardCount={pendingCardCount}
-                  pendingStakeCount={ARENA_BATCH_MODE ? rankFlowCartCount : 0}
+                  pendingStakeCount={0}
                   batchMode={ARENA_BATCH_MODE}
                   isWalletConnected={isConnected}
                   contestTitle={activeList?.title}
@@ -4063,10 +4201,7 @@ const RankedList: React.FC = () => {
                   onSubmitAndContinue={beginArenaCommit}
                   onRandomGame={onCompareRandomGame}
                   onPickNextGame={exitToArenaBrowse}
-                  onOpenConvictionCart={() => {
-                    playArenaUiClick();
-                    setBatchModalOpen(true);
-                  }}
+                  gameActionsOnly={ARENA_CONTEST_FLOW_V2}
                   onOpenSignal={() => {
                     playArenaUiClick();
                     setClimbViewMode('signal');
@@ -4155,17 +4290,19 @@ const RankedList: React.FC = () => {
               </div>
             </div>
           )}
-          <ArenaClimbTerrace
-            queuedBatchCount={ARENA_BATCH_MODE ? batchModalRows.length : 0}
-            onReviewBatch={
-              ARENA_BATCH_MODE
-                ? () => {
-                    playArenaUiClick();
-                    setBatchModalOpen(true);
-                  }
-                : undefined
-            }
-          />
+          {!ARENA_CONTEST_FLOW_V2 ? (
+            <ArenaClimbTerrace
+              queuedBatchCount={ARENA_BATCH_MODE ? batchModalRows.length : 0}
+              onReviewBatch={
+                ARENA_BATCH_MODE
+                  ? () => {
+                      playArenaUiClick();
+                      setBatchModalOpen(true);
+                    }
+                  : undefined
+              }
+            />
+          ) : null}
                 </>
               </div>
             )}
@@ -4435,7 +4572,7 @@ const RankedList: React.FC = () => {
         </div>
       )}
 
-      {ARENA_BATCH_MODE && listId && (
+      {ARENA_BATCH_MODE && listId && !ARENA_CONTEST_FLOW_V2 && (
         <ArenaBatchReviewModal
           open={batchModalOpen}
           onClose={() => {
@@ -4469,13 +4606,15 @@ const RankedList: React.FC = () => {
         payload={arenaBatchSuccess}
         onClose={() => {
           setArenaBatchSuccess(null);
-          /**
-           * Dismissing batch success ends the Compare chain: jump back to contests.
-           */
-          if (commitPhase === 'rank-batch') {
-            setCommitPhase('idle');
-            exitToArenaBrowse();
+          /** Stay on Compare after signing — do not kick the user back to the hub. */
+          if (
+            ARENA_CONTEST_FLOW_V2 &&
+            listId &&
+            (arenaFlowPhase === 'curate' || arenaFlowPhase === 'rank' || arenaFlowPhase === 'compare')
+          ) {
+            setArenaFlowPhase('compare');
           }
+          setCommitPhase('idle');
         }}
       />
 
@@ -4648,7 +4787,7 @@ const RankedList: React.FC = () => {
            * commit chain so the Compare CTA stays "Sign + pick next game"
            * rather than silently advancing.
            */
-          if (commitPhase === 'promote') {
+          if (commitPhase === 'promote' || commitPhase === 'rank-publish') {
             setCommitPhase('idle');
           }
         }}
@@ -4656,15 +4795,18 @@ const RankedList: React.FC = () => {
         contestTitle={activeList?.title ?? 'New contest'}
         contestDescription={activeList && 'description' in activeList ? activeList.description : undefined}
         items={
-          /** Prefer the curated pool (broader on-chain canvas); fall back to the user's deck. */
-          pool.length > 0
-            ? pool.map((p) => ({
+          /**
+           * Rank → Publish and compare: mint only the user's deck (not the full curate pool).
+           * Compare-step promote keeps the broader pool when the deck is empty.
+           */
+          commitPhase === 'rank-publish' || rankDeckItems.length > 0
+            ? rankDeckItems.map((p) => ({
                 id: p.id,
                 label: p.label,
                 subtitle: p.subtitle,
                 image: p.image,
               }))
-            : rankDeckItems.map((p) => ({
+            : pool.map((p) => ({
                 id: p.id,
                 label: p.label,
                 subtitle: p.subtitle,
@@ -4673,6 +4815,7 @@ const RankedList: React.FC = () => {
         }
         walletAddress={address ?? null}
         isWalletConnected={isConnected}
+        onMintContest={commitPhase === 'rank-publish' ? handleArenaMintContest : undefined}
         onPromoted={(result: ArenaPromoteListResult) => {
           /** Register the freshly minted list so Hub / Compare / portfolio all see it. */
           const arenaCategory = activeList?.arenaCategory ?? 'network';
@@ -4710,7 +4853,10 @@ const RankedList: React.FC = () => {
           const oldListId = listId;
           if (oldListId && oldListId !== portalId) {
             try {
-              const rows = loadPendingForList(oldListId);
+              const rows = remapPendingRowsMemberTermIds(
+                loadPendingForList(oldListId),
+                result.memberTermIds,
+              );
               if (rows.length > 0) savePendingForList(portalId, rows);
               clearPendingForList(oldListId);
             } catch (e) {
@@ -4718,28 +4864,80 @@ const RankedList: React.FC = () => {
             }
           }
 
-          setPromoteContestOpen(false);
-          toast.success(`"${portalEntry.title}" is live on-chain.`);
+          /** Rank step: mint + rank stakes (in modal), then Compare. */
+          if (commitPhase === 'rank-publish') {
+            const remappedDeck = rankDeckItems.map((it) => {
+              const tid = result.memberTermIds.get(it.id);
+              return tid ? { ...it, id: tid } : it;
+            });
+            const remappedTrust: Record<string, number> = {};
+            for (const it of rankDeckItems) {
+              const newId = result.memberTermIds.get(it.id) ?? it.id;
+              remappedTrust[newId] = rankTrustUnits[it.id] ?? 1;
+            }
+            setRankDeckItems(remappedDeck);
+            setRankTrustUnits(remappedTrust);
+            writePersistedContestFlow(portalId, {
+              phase: 'compare',
+              rankOrderIds: remappedDeck.map((x) => x.id),
+              rankTrustUnits: remappedTrust,
+            });
+            if (oldListId) clearPersistedContestFlow(oldListId);
 
-          /**
-           * Promote-only exits here. Mid-commit replaces URL/listId and continues to rank-batch
-           * so signing stays one flow.
-           */
-          if (commitPhase !== 'promote') {
-            navigate(`/climb?list=${encodeURIComponent(portalId)}`);
+            clearPendingStorage();
+            clearPendingForList(portalId);
+            if (oldListId) clearPendingForList(oldListId);
+            setPendingRows([]);
+
+            portalPromoteLandingRef.current = portalId;
+            setPromoteContestOpen(false);
+            setBatchModalOpen(false);
+            setCommitPhase('idle');
+            setArenaFlowPhase('compare');
+            toast.success(`"${portalEntry.title}" is live — rank stakes confirmed.`);
+            navigate(`/climb?list=${encodeURIComponent(portalId)}`, { replace: true });
+            setListId(portalId);
+
+            if (address) {
+              recordArenaRankingPicks(address, remappedDeck.length);
+              recordArenaStreakPicks(address, remappedDeck.length);
+              setPickCreditTick((n) => n + 1);
+              void refreshArenaXpSelf();
+              void refreshPlayers({ silent: true });
+              try {
+                window.dispatchEvent(new Event('inturank-arena-onchain-updated'));
+              } catch {
+                /* ignore */
+              }
+            }
             return;
           }
 
-          /** Stay on Compare; update URL + listId so the page picks up portal data. */
+          setRankDeckItems((prev) =>
+            prev.map((it) => {
+              const tid = result.memberTermIds.get(it.id);
+              return tid ? { ...it, id: tid } : it;
+            }),
+          );
+
+          setPromoteContestOpen(false);
+          toast.success(`"${portalEntry.title}" is live on-chain.`);
+
           navigate(`/climb?list=${encodeURIComponent(portalId)}`, { replace: true });
           setListId(portalId);
+
+          /**
+           * Compare-step promote: stay on Compare; optionally continue to rank-batch sign.
+           */
+          if (commitPhase !== 'promote') {
+            return;
+          }
 
           const hasQueuedStakes = ARENA_BATCH_MODE && oldListId
             ? loadPendingForList(portalId).length > 0
             : false;
           if (hasQueuedStakes) {
             setCommitPhase('rank-batch');
-            /** Wait a tick so the listId state propagates before the batch modal reads it. */
             setTimeout(() => setBatchModalOpen(true), 60);
           } else {
             setCommitPhase('idle');

--- a/services/arenaPendingBatch.ts
+++ b/services/arenaPendingBatch.ts
@@ -124,6 +124,57 @@ export function clearPendingForList(listId: string) {
   writeStore(all);
 }
 
+/** Build vault-deposit rows from the rank deck right after mint (no conviction cart). */
+export function buildArenaRankStakeRows(input: {
+  deck: Array<{
+    id: string;
+    kind: ArenaPendingRow['item']['kind'];
+    label: string;
+    subtitle?: string;
+    image?: string;
+    imageSecondary?: string;
+    versusLeftLabel?: string;
+    versusRightLabel?: string;
+    pairKind: string;
+  }>;
+  rankTrustUnits: Record<string, number>;
+  memberTermIds: Map<string, `0x${string}`>;
+  sourceListId: string;
+}): ArenaPendingRowWithSource[] {
+  return input.deck.map((it, i) => {
+    const onChainId = input.memberTermIds.get(it.id) ?? it.id;
+    return {
+      key: `rank-publish-${onChainId}-${i}`,
+      item: {
+        id: onChainId,
+        kind: it.kind,
+        label: it.label,
+        subtitle: it.subtitle,
+        image: it.image,
+        imageSecondary: it.imageSecondary,
+        versusLeftLabel: it.versusLeftLabel,
+        versusRightLabel: it.versusRightLabel,
+        pairKind: it.pairKind,
+      },
+      support: true,
+      units: Math.max(1, Math.min(12, input.rankTrustUnits[it.id] ?? 1)),
+      sourceListId: input.sourceListId,
+    };
+  });
+}
+
+/** After promote, map local deck ids → on-chain member atom term ids for portal vault deposits. */
+export function remapPendingRowsMemberTermIds(
+  rows: ArenaPendingRow[],
+  memberTermIds: Map<string, `0x${string}`>,
+): ArenaPendingRow[] {
+  return rows.map((row) => {
+    const tid = memberTermIds.get(row.item.id);
+    if (!tid) return row;
+    return { ...row, item: { ...row.item, id: tid } };
+  });
+}
+
 /** Total queued stances across all lists (for global FAB). */
 export function getTotalPendingCount(): number {
   const s = readStore();

--- a/services/arenaPromoteList.ts
+++ b/services/arenaPromoteList.ts
@@ -21,7 +21,7 @@ import { parseEther } from 'viem';
 import {
   atomRefJobKey,
   batchEnsureAtomTermIds,
-  createIdentityAtom,
+  ensureIdentityAtom,
   createSemanticTriplesBatch,
   publicClient,
   type SemanticTripleBatchInput,
@@ -85,8 +85,15 @@ export async function promoteArenaListOnChain(
   if (!wallet || !wallet.startsWith('0x')) throw new Error('Wallet not connected.');
   if (!items.length) throw new Error('Need at least one member to promote this contest.');
 
+  const seenLabels = new Set<string>();
   const trimmedItems = items
     .filter((it) => it.label && it.label.trim().length > 0)
+    .filter((it) => {
+      const key = it.label.trim().toLowerCase();
+      if (seenLabels.has(key)) return false;
+      seenLabels.add(key);
+      return true;
+    })
     .slice(0, ARENA_PROMOTE_MAX_MEMBERS);
   if (!trimmedItems.length) throw new Error('No member labels to anchor.');
 
@@ -97,18 +104,20 @@ export async function promoteArenaListOnChain(
     description: description?.trim() || undefined,
     type: 'List' as const,
   };
-  const { hash: listTxHash, termId: listTermId } = await createIdentityAtom(
+  const { hash: listTxHash, termId: listTermId } = await ensureIdentityAtom(
     listMeta,
     depositPerLeg,
     wallet,
     (m) => onProgress?.(`List atom · ${m}`),
   );
   if (!listTermId) {
-    throw new Error('List atom transaction confirmed but the term id was not resolved.');
+    throw new Error('List atom could not be resolved on-chain.');
   }
   onProgress?.(`List atom anchored · ${listTermId.slice(0, 10)}…`);
-  /** Belt-and-suspenders: wait for the receipt so the triple step has a real anchor. */
-  await publicClient.waitForTransactionReceipt({ hash: listTxHash });
+  /** Wait only when we actually broadcast a new list atom (reuse skips the tx). */
+  if (listTxHash && !/^0x0{64}$/i.test(listTxHash)) {
+    await publicClient.waitForTransactionReceipt({ hash: listTxHash });
+  }
 
   /* ────────── 2) Resolve / mint member atoms (batched) ────────── */
   onProgress?.(`Resolving ${trimmedItems.length} member atom(s)…`);
@@ -149,11 +158,18 @@ export async function promoteArenaListOnChain(
   const triplesTxHash = await createSemanticTriplesBatch(tripleLegs, wallet, (m) =>
     onProgress?.(`Triples · ${m}`),
   );
+  if (triplesTxHash && !/^0x0{64}$/i.test(triplesTxHash)) {
+    try {
+      await publicClient.waitForTransactionReceipt({ hash: triplesTxHash });
+    } catch {
+      /* receipt polling is best-effort; triples may still be indexed */
+    }
+  }
   onProgress?.('Contest is live on-chain.');
 
   return {
     listTermId,
-    listTxHash,
+    listTxHash: listTxHash ?? ('0x0000000000000000000000000000000000000000000000000000000000000000' as `0x${string}`),
     triplesTxHash,
     memberTermIds,
     members: trimmedItems,

--- a/services/arenaSimilarity.ts
+++ b/services/arenaSimilarity.ts
@@ -13,8 +13,129 @@
  *  - For portal lists with no peer claims we return `null` (no overlap).
  *  - Only when there is real overlap do we return a similarity score.
  */
-import type { UserArenaRankingClaim } from './graphql';
+import { formatEther } from 'viem';
+import type { ArenaProxyDepositRow, UserArenaRankingClaim } from './graphql';
 import type { RankItem } from '../pages/RankedList';
+
+/** One row in a peer's full list ranking (ordered by accumulated TRUST on this list). */
+export type PortalListRankRow = {
+  rank: number;
+  subjectId: string;
+  label: string;
+  image?: string;
+  support: boolean;
+  trustWei: bigint;
+  trustLabel: string;
+};
+
+function formatTrustWei(wei: bigint): string {
+  if (wei <= 0n) return '—';
+  const t = parseFloat(formatEther(wei));
+  if (!Number.isFinite(t) || t <= 0) return '—';
+  if (t >= 100) return `${Math.round(t)}`;
+  const rounded = Math.round(t * 100) / 100;
+  return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(2).replace(/\.?0+$/, '');
+}
+
+function listTermMatches(a: string, b: string): boolean {
+  return String(a).toLowerCase() === String(b).toLowerCase();
+}
+
+/**
+ * Build a peer's ordered ranking for one portal list: total TRUST per identity
+ * (all FeeProxy deposits on YES vaults add up), highest first. Latest YES/NO per
+ * subject comes from their indexed claims.
+ */
+export function buildPortalListRankingByAccumulatedTrust(
+  wallet: string,
+  listTermId: string,
+  peerClaims: UserArenaRankingClaim[],
+  deposits: ArenaProxyDepositRow[],
+  stanceByVault: Map<
+    string,
+    {
+      support: boolean;
+      stance: {
+        listTermId: string;
+        subjectId: string;
+        subjectLabel: string;
+        subjectImage?: string;
+      };
+    }
+  >,
+): PortalListRankRow[] {
+  const walletLc = wallet.trim().toLowerCase();
+  if (!walletLc || !listTermId) return [];
+
+  const latestSupport = new Map<string, boolean>();
+  const meta = new Map<string, { label: string; image?: string }>();
+  for (const c of peerClaims) {
+    if (!listTermMatches(c.listTermId, listTermId)) continue;
+    const sid = String(c.subjectId).toLowerCase();
+    latestSupport.set(sid, Boolean(c.support));
+    if (!meta.has(sid)) {
+      meta.set(sid, { label: c.subjectLabel, image: c.subjectImage });
+    }
+  }
+
+  const trustBySubject = new Map<string, bigint>();
+  for (const dep of deposits) {
+    if (normalizeReceiver(dep.receiverId) !== walletLc) continue;
+    const stance = stanceByVault.get(dep.vaultTermId);
+    if (!stance || !listTermMatches(stance.stance.listTermId, listTermId)) continue;
+    if (!stance.support) continue;
+    const wei = dep.assetsAfterFeesWei ?? 0n;
+    if (wei <= 0n) continue;
+    const sid = String(stance.stance.subjectId).toLowerCase();
+    trustBySubject.set(sid, (trustBySubject.get(sid) ?? 0n) + wei);
+    if (!meta.has(sid)) {
+      meta.set(sid, {
+        label: stance.stance.subjectLabel,
+        image: stance.stance.subjectImage,
+      });
+    }
+  }
+
+  /** Fallback when deposit amounts are missing: order by latest YES stakes. */
+  if (trustBySubject.size === 0) {
+    const yesRows = peerClaims
+      .filter((c) => listTermMatches(c.listTermId, listTermId) && c.support)
+      .sort((a, b) => b.blockNumber - a.blockNumber);
+    return yesRows.map((c, i) => ({
+      rank: i + 1,
+      subjectId: c.subjectId,
+      label: c.subjectLabel,
+      image: c.subjectImage,
+      support: true,
+      trustWei: 0n,
+      trustLabel: '—',
+    }));
+  }
+
+  const sorted = [...trustBySubject.entries()].sort((a, b) => {
+    if (b[1] > a[1]) return 1;
+    if (b[1] < a[1]) return -1;
+    return 0;
+  });
+
+  return sorted.map(([sid, wei], i) => {
+    const m = meta.get(sid);
+    return {
+      rank: i + 1,
+      subjectId: sid,
+      label: m?.label ?? 'Pick',
+      image: m?.image,
+      support: latestSupport.get(sid) ?? true,
+      trustWei: wei,
+      trustLabel: formatTrustWei(wei),
+    };
+  });
+}
+
+function normalizeReceiver(id: string): string {
+  const t = id.trim().toLowerCase();
+  return t.startsWith('0x') ? t : t;
+}
 
 export type ArenaSimilarityResult = {
   /** 0–100, weighted agreement on items in your deck. */

--- a/services/graphql.ts
+++ b/services/graphql.ts
@@ -3031,40 +3031,64 @@ export async function fetchDistinctReceiversForPortalListFromProxyDeposits(
 
   const depLimit = Math.min(5200, Math.max(1800, maxWallets * 80));
   try {
-    const deposits = await fetchProxyArenaRankDeposits(depLimit);
-    if (!deposits.length) return [];
-
+    const deposits = await fetchProxyArenaRankDepositsCached(depLimit);
     const vaultIds = Array.from(new Set(deposits.map((d) => d.vaultTermId)));
     const stanceByVault = await fetchArenaVaultStanceMap(vaultIds);
-    if (!stanceByVault.size) return [];
-
-    const out: string[] = [];
-    const seenRecv = new Set<string>();
-
-    for (const dep of deposits) {
-      const stance = stanceByVault.get(dep.vaultTermId);
-      if (!stance) continue;
-      if (minBnLb != null && stance.stance.blockNumber > 0 && stance.stance.blockNumber < minBnLb) continue;
-      if (!portalListStanceMatchesListObject(stance.stance.listTermId, listObjectTermId)) continue;
-
-      let recv: string;
-      try {
-        recv = getAddress(dep.receiverId as `0x${string}`);
-      } catch {
-        continue;
-      }
-      const lc = recv.toLowerCase();
-      if (exclude.has(lc) || operators.has(lc)) continue;
-      if (seenRecv.has(lc)) continue;
-      seenRecv.add(lc);
-      out.push(recv);
-      if (out.length >= maxWallets) break;
-    }
-    return out;
+    return discoverPortalListRankerReceiversFromDeposits(
+      listObjectTermId,
+      excludeWallet,
+      maxWallets,
+      deposits,
+      stanceByVault,
+    );
   } catch (e) {
     console.warn('[fetchDistinctReceiversForPortalListFromProxyDeposits]', e);
     return [];
   }
+}
+
+/**
+ * Derive human ranker wallets for one portal list from an already-fetched deposit + stance bundle
+ * (avoids a second full-graph deposit scan during Compare).
+ */
+export function discoverPortalListRankerReceiversFromDeposits(
+  listObjectTermId: string,
+  excludeWallet: string | undefined,
+  maxWallets: number,
+  deposits: ArenaProxyDepositRow[],
+  stanceByVault: Map<string, ArenaVaultStance>,
+): string[] {
+  const ids = prepareQueryIds(listObjectTermId.trim());
+  if (!ids.length || maxWallets <= 0 || !deposits.length) return [];
+
+  const exclude = new Set((excludeWallet ? prepareQueryIds(excludeWallet) : []).map((x) => normalize(x)));
+  const operators = protocolOperatorCreatorIdsNormalized();
+  const minBnLb = ARENA_ATTRIBUTION_MIN_BLOCK;
+  if (!stanceByVault.size) return [];
+
+  const out: string[] = [];
+  const seenRecv = new Set<string>();
+
+  for (const dep of deposits) {
+    const stance = stanceByVault.get(dep.vaultTermId);
+    if (!stance) continue;
+    if (minBnLb != null && stance.stance.blockNumber > 0 && stance.stance.blockNumber < minBnLb) continue;
+    if (!portalListStanceMatchesListObject(stance.stance.listTermId, listObjectTermId)) continue;
+
+    let recv: string;
+    try {
+      recv = getAddress(dep.receiverId as `0x${string}`);
+    } catch {
+      continue;
+    }
+    const lc = recv.toLowerCase();
+    if (exclude.has(lc) || operators.has(lc)) continue;
+    if (seenRecv.has(lc)) continue;
+    seenRecv.add(lc);
+    out.push(recv);
+    if (out.length >= maxWallets) break;
+  }
+  return out;
 }
 
 /**
@@ -3203,30 +3227,50 @@ export async function fetchPortfolioArenaRankingClaims(wallet: string): Promise<
   return fetchUserArenaRankingClaimsWithAllowlist(wallet, allow);
 }
 
-async function fetchUserArenaRankingClaimsWithAllowlist(
-  wallet: string,
+/**
+ * Build portal ranking claims for many wallets from one deposit + stance scan (Compare batch path).
+ */
+export function buildArenaRankingClaimsForReceivers(
+  wallets: string[],
+  deposits: ArenaProxyDepositRow[],
+  stanceByVault: Map<string, ArenaVaultStance>,
   allow: Set<string>,
-): Promise<UserArenaRankingClaim[]> {
-  const recvVariants = prepareQueryIds(wallet.trim());
-  if (!recvVariants.length) return [];
-  const recvSet = new Set(recvVariants.map(normalize));
+): Map<string, UserArenaRankingClaim[]> {
+  const out = new Map<string, UserArenaRankingClaim[]>();
+  if (allow.size === 0 || wallets.length === 0 || deposits.length === 0 || stanceByVault.size === 0) {
+    return out;
+  }
 
-  try {
-    if (allow.size === 0) return [];
+  const operatorCreators = protocolOperatorCreatorIdsNormalized();
+  const minBnLb = ARENA_ATTRIBUTION_MIN_BLOCK;
 
-    const operatorCreators = protocolOperatorCreatorIdsNormalized();
-    const minBnLb = ARENA_ATTRIBUTION_MIN_BLOCK;
+  const walletVariantSets = new Map<string, Set<string>>();
+  for (const w of wallets) {
+    const variants = prepareQueryIds(w.trim());
+    if (!variants.length) continue;
+    const primary = normalize(variants[0]!);
+    if (walletVariantSets.has(primary)) continue;
+    walletVariantSets.set(primary, new Set(variants.map(normalize)));
+  }
 
-    const depositsAll = await fetchProxyArenaRankDeposits(4200);
-    const userDeps = depositsAll.filter((d) => {
-      const recvLc = normalize(d.receiverId);
-      return recvLc && recvSet.has(recvLc) && !operatorCreators.has(recvLc);
-    });
-    if (userDeps.length === 0) return [];
+  const depsByWallet = new Map<string, ArenaProxyDepositRow[]>();
+  for (const dep of deposits) {
+    const recvLc = normalize(dep.receiverId);
+    if (!recvLc || operatorCreators.has(recvLc)) continue;
+    for (const [walletKey, variantSet] of walletVariantSets) {
+      if (!variantSet.has(recvLc)) continue;
+      const bucket = depsByWallet.get(walletKey);
+      if (bucket) bucket.push(dep);
+      else depsByWallet.set(walletKey, [dep]);
+    }
+  }
 
-    const vaultIds = Array.from(new Set(userDeps.map((d) => d.vaultTermId)));
-    const stanceByVault = await fetchArenaVaultStanceMap(vaultIds);
-    if (stanceByVault.size === 0) return [];
+  for (const walletKey of walletVariantSets.keys()) {
+    const userDeps = depsByWallet.get(walletKey) ?? [];
+    if (userDeps.length === 0) {
+      out.set(walletKey, []);
+      continue;
+    }
 
     const seenWalletStake = new Set<string>();
     const rawStakes: ArenaGraphTripleStanceRow[] = [];
@@ -3263,7 +3307,27 @@ async function fetchUserArenaRankingClaimsWithAllowlist(
       if (!prev || row.blockNumber >= prev.blockNumber) bySlot.set(slotKey, row);
     }
 
-    return Array.from(bySlot.values()).sort((a, b) => b.blockNumber - a.blockNumber);
+    out.set(walletKey, Array.from(bySlot.values()).sort((a, b) => b.blockNumber - a.blockNumber));
+  }
+
+  return out;
+}
+
+async function fetchUserArenaRankingClaimsWithAllowlist(
+  wallet: string,
+  allow: Set<string>,
+): Promise<UserArenaRankingClaim[]> {
+  const recvVariants = prepareQueryIds(wallet.trim());
+  if (!recvVariants.length) return [];
+
+  try {
+    if (allow.size === 0) return [];
+
+    const depositsAll = await fetchProxyArenaRankDepositsCached(2600);
+    const vaultIds = Array.from(new Set(depositsAll.map((d) => d.vaultTermId)));
+    const stanceByVault = await fetchArenaVaultStanceMap(vaultIds);
+    const primary = normalize(recvVariants[0]!);
+    return buildArenaRankingClaimsForReceivers([wallet], depositsAll, stanceByVault, allow).get(primary) ?? [];
   } catch (e) {
     console.warn('[fetchUserArenaRankingClaimsWithAllowlist]', e);
     return [];
@@ -3443,20 +3507,53 @@ function protocolOperatorCreatorIdsNormalized(): Set<string> {
   return s;
 }
 
-type ArenaProxyDepositRow = {
+export type ArenaProxyDepositRow = {
   vaultTermId: string;
   receiverId: string;
   receiverLabel?: string;
   receiverImage?: string;
   createdAt: number;
   transactionHash?: string;
+  /** TRUST routed through FeeProxy for this deposit (wei). */
+  assetsAfterFeesWei?: bigint;
 };
+
+/** Dedupe heavy deposit scans (Compare was re-fetching 4200 rows per peer wallet). */
+let proxyArenaDepositsCache: {
+  limit: number;
+  fetchedAt: number;
+  promise: Promise<ArenaProxyDepositRow[]>;
+} | null = null;
+const PROXY_ARENA_DEPOSITS_CACHE_MS = 55_000;
+
+export async function fetchProxyArenaRankDepositsCached(limit = 800): Promise<ArenaProxyDepositRow[]> {
+  const now = Date.now();
+  if (
+    proxyArenaDepositsCache &&
+    proxyArenaDepositsCache.limit >= limit &&
+    now - proxyArenaDepositsCache.fetchedAt < PROXY_ARENA_DEPOSITS_CACHE_MS
+  ) {
+    return proxyArenaDepositsCache.promise;
+  }
+  const promise = fetchProxyArenaRankDeposits(limit);
+  proxyArenaDepositsCache = {
+    limit,
+    fetchedAt: now,
+    promise,
+  };
+  return promise;
+}
+
+export function invalidateProxyArenaRankDepositsCache(): void {
+  proxyArenaDepositsCache = null;
+  compareGraphBundleCache = null;
+}
 
 /**
  * Recent deposits routed through IntuRank's FeeProxy/MultiVault — the canonical "ranked through IntuRank" signal.
  * `sender_id` on the deposit row pins us as the originator regardless of when/who first created the triple.
  */
-async function fetchProxyArenaRankDeposits(limit = 800): Promise<ArenaProxyDepositRow[]> {
+export async function fetchProxyArenaRankDeposits(limit = 800): Promise<ArenaProxyDepositRow[]> {
   const proxyIds = Array.from(
     new Set([FEE_PROXY_ADDRESS, MULTI_VAULT_ADDRESS].flatMap((a) => prepareQueryIds(a))),
   );
@@ -3468,6 +3565,7 @@ async function fetchProxyArenaRankDeposits(limit = 800): Promise<ArenaProxyDepos
     ) {
       created_at
       transaction_hash
+      assets_after_fees
       receiver { id label image }
       vault { term_id }
     }
@@ -3485,6 +3583,13 @@ async function fetchProxyArenaRankDeposits(limit = 800): Promise<ArenaProxyDepos
         if (typeof v === 'string') return parseInt(v, 10) || 0;
         return 0;
       })();
+      let assetsAfterFeesWei: bigint | undefined;
+      try {
+        const raw = d?.assets_after_fees;
+        if (raw != null && String(raw) !== '') assetsAfterFeesWei = BigInt(String(raw));
+      } catch {
+        /* ignore */
+      }
       out.push({
         vaultTermId: tid,
         receiverId: recv,
@@ -3492,6 +3597,7 @@ async function fetchProxyArenaRankDeposits(limit = 800): Promise<ArenaProxyDepos
         receiverImage: d?.receiver?.image || undefined,
         createdAt,
         transactionHash: d?.transaction_hash || undefined,
+        assetsAfterFeesWei,
       });
     }
     return out;
@@ -3515,7 +3621,7 @@ type ArenaVaultStance = {
  * surface every one regardless of predicate shape. We still surface YES (member) and NO (counter)
  * vault sides distinctly.
  */
-async function fetchArenaVaultStanceMap(
+export async function fetchArenaVaultStanceMap(
   vaultTermIds: string[],
 ): Promise<Map<string, ArenaVaultStance>> {
   const ids = Array.from(new Set(vaultTermIds.flatMap((id) => prepareQueryIds(id).map(normalize)))).slice(0, 480);
@@ -3590,6 +3696,51 @@ async function fetchArenaVaultStanceMap(
     console.warn('[fetchArenaVaultStanceMap]', e);
     return new Map();
   }
+}
+
+/** One deposit + stance + allowlist bundle per Compare visit (not per peer). */
+export type ArenaCompareGraphBundle = {
+  deposits: ArenaProxyDepositRow[];
+  stanceByVault: Map<string, ArenaVaultStance>;
+  allow: Set<string>;
+};
+
+let compareGraphBundleCache: {
+  depositLimit: number;
+  fetchedAt: number;
+  promise: Promise<ArenaCompareGraphBundle>;
+} | null = null;
+
+const ARENA_COMPARE_GRAPH_DEPOSIT_LIMIT = 2600;
+const ARENA_COMPARE_GRAPH_BUNDLE_TTL_MS = 50_000;
+
+/**
+ * Prefetch everything Compare needs in two graph round-trips (deposits + vault triples) plus allowlist.
+ */
+export async function fetchArenaCompareGraphBundle(
+  depositLimit = ARENA_COMPARE_GRAPH_DEPOSIT_LIMIT,
+): Promise<ArenaCompareGraphBundle> {
+  const now = Date.now();
+  if (
+    compareGraphBundleCache &&
+    compareGraphBundleCache.depositLimit >= depositLimit &&
+    now - compareGraphBundleCache.fetchedAt < ARENA_COMPARE_GRAPH_BUNDLE_TTL_MS
+  ) {
+    return compareGraphBundleCache.promise;
+  }
+
+  const promise = (async (): Promise<ArenaCompareGraphBundle> => {
+    const [allow, deposits] = await Promise.all([
+      getArenaPortalRankingAllowlist(),
+      fetchProxyArenaRankDepositsCached(depositLimit),
+    ]);
+    const vaultIds = Array.from(new Set(deposits.map((d) => d.vaultTermId)));
+    const stanceByVault = await fetchArenaVaultStanceMap(vaultIds);
+    return { deposits, stanceByVault, allow };
+  })();
+
+  compareGraphBundleCache = { depositLimit, fetchedAt: now, promise };
+  return promise;
 }
 
 /**

--- a/services/signalStanceOnchain.ts
+++ b/services/signalStanceOnchain.ts
@@ -1,5 +1,5 @@
 /**
- * Pulse / Signal: submit queued Support or Oppose stances as FeeProxy vault deposits.
+ * Pulse / Signal — submit queued Support (stand) or Oppose stances as FeeProxy vault deposits.
  * Mirrors Arena portal semantics: positive vault vs counter vault, with counter-stake checks.
  */
 import { getAddress, parseEther } from 'viem';
@@ -11,7 +11,6 @@ import {
   getRawShareBalance,
   grantProxyApproval,
   hasCachedProxyApproval,
-  switchNetwork,
 } from './web3';
 import { LINEAR_CURVE_ID, OFFSET_PROGRESSIVE_CURVE_ID } from '../constants';
 
@@ -43,8 +42,6 @@ export async function submitSignalStancesOnChain(
   onProgress?: (m: string) => void,
 ): Promise<`0x${string}`[]> {
   if (!picks.length) throw new Error('No stances to submit.');
-  onProgress?.('Confirming network…');
-  await switchNetwork();
   const receiver = getAddress(String(wallet).trim() as `0x${string}`);
 
   let proxyOk = hasCachedProxyApproval(receiver);

--- a/services/signalVouchOnchain.ts
+++ b/services/signalVouchOnchain.ts
@@ -1,6 +1,6 @@
 /**
- * Flush queued Signal vouches through FeeProxy (`createTriples` batch).
- * Triple shape: your account term, predicate "vouches for", target account/thing term.
+ * Phase D — flush queued Signal vouches as one FeeProxy `createTriples` batch.
+ * Triple shape: (your Account atom) — vouches for → (target Account or Thing atom).
  */
 import { getAddress, isAddress, parseEther } from 'viem';
 import type { SignalVouchPick } from './signalPendingBatch';
@@ -10,7 +10,6 @@ import {
     looksLikeBytes32TermId,
     padTermId,
     resolveAtomReferenceToTermId,
-    switchNetwork,
     type SemanticTripleBatchInput,
 } from './web3';
 
@@ -23,8 +22,6 @@ export async function submitSignalVouchesOnChain(
     onProgress?: (m: string) => void,
 ): Promise<`0x${string}`> {
     if (!picks.length) throw new Error('No vouches to submit.');
-    onProgress?.('Confirming network…');
-    await switchNetwork();
 
     const receiver = getAddress(String(wallet).trim() as `0x${string}`);
     const dep = parseEther(depositTrust.trim());
@@ -40,7 +37,7 @@ export async function submitSignalVouchesOnChain(
 
     for (let i = 0; i < picks.length; i++) {
         const p = picks[i]!;
-        onProgress?.(`Resolving vouch ${i + 1} / ${picks.length}: ${p.label.slice(0, 32)}…`);
+        onProgress?.(`Resolving vouch ${i + 1} / ${picks.length} — ${p.label.slice(0, 32)}…`);
 
         let cacheKey: string;
         if (p.objectTermId && looksLikeBytes32TermId(p.objectTermId.trim())) {

--- a/services/web3.ts
+++ b/services/web3.ts
@@ -215,60 +215,21 @@ export const getConnectedAccount = async (): Promise<string | null> => {
   } catch { return null; }
 };
 
-function isUserRejectedError(error: unknown, depth = 0): boolean {
+function isUserRejectedError(error: unknown): boolean {
   if (error instanceof UserRejectedRequestError) return true;
-  if (depth > 4) return false;
   if (typeof error === 'object' && error !== null) {
-    const e = error as {
-      code?: number | string;
-      name?: string;
-      message?: string;
-      shortMessage?: string;
-      details?: string;
-      cause?: unknown;
-    };
-    if (e.code === 4001 || e.code === 'ACTION_REJECTED') return true;
+    const e = error as { code?: number; name?: string };
+    if (e.code === 4001) return true;
     if (e.name === 'UserRejectedRequestError') return true;
-    const s =
-      `${e.message ?? ''} ${String(e.shortMessage ?? '')} ${String(e.details ?? '')}`.toLowerCase();
-    if (
-      /user reject|rejected the request|transaction rejected|denied transaction signing|ethers-user-denied|wallet.*reject|user denied|request rejected|action_rejected|\b4001\b|cancelled|\bcancel\b|\bcanceled\b|action canceled/i.test(
-        s
-      )
-    ) {
-      return true;
-    }
-    if (e.cause !== undefined && e.cause !== null) return isUserRejectedError(e.cause, depth + 1);
   }
+  const msg = String((error as { message?: string })?.message ?? error ?? '').toLowerCase();
+  if (msg.includes('user rejected') || msg.includes('user denied')) return true;
   return false;
 }
 
-/** Shared UI helper: distinguish user-dismissed prompts from real faults (switch, approvals, txs). */
+/** Public alias for batch / Arena flows (MetaMask reject, viem UserRejectedRequestError). */
 export function isUserRejectedWalletError(error: unknown): boolean {
   return isUserRejectedError(error);
-}
-
-/** Current wallet chain id from the active EIP‑1193 provider, or null if unavailable. */
-export async function readConnectedWalletChainId(): Promise<number | null> {
-  const p = getProvider();
-  if (!p?.request) return null;
-  try {
-    const hex = (await p.request({ method: 'eth_chainId' })) as string;
-    return typeof hex === 'string' ? parseInt(hex, 16) : null;
-  } catch {
-    return null;
-  }
-}
-
-/** Throws if the wallet is not on Intuition RPC `CHAIN_ID` (call after prompting switch). */
-export async function assertWalletOnConfiguredChain(): Promise<void> {
-  const id = await readConnectedWalletChainId();
-  if (id == null) {
-    throw new Error('Wallet not connected. Connect your wallet, then retry.');
-  }
-  if (id !== CHAIN_ID) {
-    throw new Error(`Wrong network (chain ${id}). Switch to ${NETWORK_NAME} (chain ${CHAIN_ID}) and try again.`);
-  }
 }
 
 /** MetaMask validates the RPC when adding a chain; Intuition’s JSON-RPC is on `/http` (bare `/` often fails). */
@@ -307,23 +268,22 @@ async function switchNetworkViaInjectedProvider(provider: NonNullable<ReturnType
     await attemptSwitch();
     return;
   } catch (error: unknown) {
-    if (isUserRejectedError(error)) throw error;
+    if (isUserRejectedError(error)) return;
     try {
       await provider.request({
         method: 'wallet_addEthereumChain',
         params: [addParams],
       });
     } catch (addError: unknown) {
-      if (isUserRejectedError(addError)) throw addError;
+      if (isUserRejectedError(addError)) return;
       // Chain may already be registered; still try switching again.
     }
     try {
       await attemptSwitch();
     } catch (e2: unknown) {
-      if (isUserRejectedError(e2)) throw e2;
+      if (isUserRejectedError(e2)) return;
       console.error('SWITCH_NETWORK_ERROR:', error, e2);
-      toast.error('Could not switch network. Pick Intuition in your wallet manually, then retry.');
-      throw new Error('Could not switch network in your wallet.');
+      toast.error('Could not switch network. Try switching to Intuition in your wallet.');
     }
   }
 }
@@ -337,32 +297,26 @@ export const switchNetwork = async () => {
     blockExplorerUrls: [EXPLORER_URL],
   };
 
-  let usedWagmi = false;
   if (typeof window !== 'undefined') {
     try {
       await wagmiSwitchChain(wagmiConfig, {
         chainId: CHAIN_ID,
         addEthereumChainParameter,
       });
-      usedWagmi = true;
+      return;
     } catch (error: unknown) {
-      if (isUserRejectedError(error)) throw error;
+      if (isUserRejectedError(error)) return;
       console.warn('wagmi switchChain failed, falling back to injected provider:', error);
     }
   }
 
-  if (!usedWagmi) {
-    const provider = getProvider();
-    if (!provider) {
-      const msg = 'Wallet not ready. Open your wallet extension, connect, then try again.';
-      toast.error(msg);
-      throw new Error(msg);
-    }
-
-    await switchNetworkViaInjectedProvider(provider);
+  const provider = getProvider();
+  if (!provider) {
+    toast.error('Wallet not ready. Wait a moment and try again, or switch network in your wallet.');
+    return;
   }
 
-  await assertWalletOnConfiguredChain();
+  await switchNetworkViaInjectedProvider(provider);
 };
 
 export type WalletConnector = 'injected' | 'walletconnect';
@@ -409,8 +363,8 @@ export const connectWallet = async (
       if (typeof window !== 'undefined') localStorage.removeItem(DISCONNECT_FLAG_KEY);
       return address;
     } catch (error: any) {
-      if (error?.code === 4001) toast.info('Wallet connection declined.');
-      else toast.error(error?.message || 'WalletConnect failed');
+      if (error?.code === 4001) toast.error("REJECTED_BY_USER");
+      else toast.error(`WALLETCONNECT_ERROR: ${error?.message || 'Failed to connect'}`);
       return null;
     }
   }
@@ -428,21 +382,14 @@ export const connectWallet = async (
     
     const chainIdHex = await provider.request({ method: 'eth_chainId' });
     if (parseInt(chainIdHex, 16) !== CHAIN_ID) {
-      try {
         await switchNetwork();
-      } catch (e: unknown) {
-        if (!isUserRejectedError(e)) {
-          toast.error(parseProtocolError(e) || (e instanceof Error ? e.message : 'Could not switch network'));
-        }
-        // Still unlock account; Wrong network banner in Layout/Mobile prompts again.
-      }
     }
     activeProvider = provider;
     if (typeof window !== 'undefined') localStorage.removeItem(DISCONNECT_FLAG_KEY);
     return address;
   } catch (error: any) {
-    if (error.code === 4001) toast.info('Connection declined in wallet.');
-    else toast.error(error?.message?.includes('Wallet not ready') ? error.message : `ERROR: ${error.message}`);
+    if (error.code === 4001) toast.error("REJECTED_BY_USER");
+    else toast.error(`ERROR: ${error.message}`);
     return null; 
   }
 };
@@ -978,7 +925,7 @@ export const grantProxyApproval = async (walletAddress: string): Promise<void> =
 
     if (fromRead || fromLogs) {
         setProxyApprovalCache(checksumAccount);
-        toast.success('Fee proxy enabled. You can submit to the chain.');
+        toast.success("HANDSHAKE_COMPLETE: Protocol enabled.");
         return;
     }
 
@@ -989,7 +936,7 @@ export const grantProxyApproval = async (walletAddress: string): Promise<void> =
         { hash }
     );
     setProxyApprovalCache(checksumAccount);
-    toast.success('Fee proxy enabled. You can submit to the chain.');
+    toast.success("HANDSHAKE_COMPLETE: Protocol enabled.");
 };
 
 const LOCAL_TX_KEY = 'inturank_ledger_v3';
@@ -1610,7 +1557,7 @@ export async function isTermCreatedOnChain(termId: string): Promise<boolean> {
 }
 
 /** Poll until `isTermCreated` reflects a tx mined in the same session (avoids MultiVault_AtomExists on duplicate picks). */
-async function waitUntilTermCreatedOnChain(
+export async function waitUntilTermCreatedOnChain(
     termId: string,
     opts?: { maxAttempts?: number; delayMs?: number },
 ): Promise<boolean> {
@@ -1866,6 +1813,45 @@ export async function createTripleFromLabels(
     }
 }
 
+/**
+ * Mint or reuse an identity/list/thing atom. Skips FeeProxy when the term is already registered
+ * (retries, partial promotes, duplicate labels).
+ */
+export async function ensureIdentityAtom(
+    metadata: any,
+    depositAmount: string,
+    receiver: string,
+    onProgress?: (log: string) => void,
+): Promise<{ hash?: `0x${string}`; termId: `0x${string}` }> {
+    const { dataHex } = await getFeeProxyAtomParams(metadata, depositAmount);
+    const candidate = await getProtocolAtomIdFromAtomData(dataHex);
+    if (await isTermCreatedOnChain(candidate)) {
+        onProgress?.('Identity already on-chain — reusing it.');
+        return { termId: candidate };
+    }
+    if (await waitUntilTermCreatedOnChain(candidate, { maxAttempts: 10, delayMs: 280 })) {
+        onProgress?.('Identity already on-chain — reusing it.');
+        return { termId: candidate };
+    }
+
+    try {
+        const { hash, termId } = await createIdentityAtom(metadata, depositAmount, receiver, onProgress);
+        const tid = termId ?? (hash ? await getAtomTermIdFromTxHash(hash, dataHex) : undefined) ?? candidate;
+        return { hash, termId: tid };
+    } catch (e) {
+        if (errorLooksLikeAtomAlreadyExists(e)) {
+            const ready =
+                (await isTermCreatedOnChain(candidate)) ||
+                (await waitUntilTermCreatedOnChain(candidate, { maxAttempts: 28, delayMs: 320 }));
+            if (ready) {
+                onProgress?.('Identity already on-chain — reusing it.');
+                return { termId: candidate };
+            }
+        }
+        throw e;
+    }
+}
+
 export const createIdentityAtom = async (metadata: any, depositAmount: string, receiver: string, onProgress?: (log: string) => void): Promise<{ hash: `0x${string}`; termId?: `0x${string}` }> => {
     const checksumReceiver = getAddress(receiver);
     const depositParsed = parseEther(depositAmount);
@@ -1879,6 +1865,13 @@ export const createIdentityAtom = async (metadata: any, depositAmount: string, r
     const walletClient = createWalletClient({ chain: intuitionChain, transport: custom(provider), account: checksumReceiver });
 
     try {
+        const { dataHex, depositWei, valueWei: totalCost } = await getFeeProxyAtomParams(metadata, depositAmount);
+        const candidate = await getProtocolAtomIdFromAtomData(dataHex);
+        if (await isTermCreatedOnChain(candidate)) {
+            onProgress?.('Identity already on-chain — reusing it.');
+            return { hash: '0x0000000000000000000000000000000000000000000000000000000000000000', termId: candidate };
+        }
+
         onProgress?.("Verifying Protocol Approval...");
         const approved = await getProxyApprovalStatus(receiver, { readRetries: 2, readDelayMs: 120 });
         if (!approved) {
@@ -1887,7 +1880,6 @@ export const createIdentityAtom = async (metadata: any, depositAmount: string, r
         }
 
         onProgress?.("Simulating atom creation (FeeProxy)...");
-        const { dataHex, depositWei, valueWei: totalCost } = await getFeeProxyAtomParams(metadata, depositAmount);
 
         onProgress?.(`Total send: ${formatEther(totalCost)} ${CURRENCY_SYMBOL}`);
         onProgress?.("Awaiting Identity Signature...");
@@ -1905,6 +1897,15 @@ export const createIdentityAtom = async (metadata: any, depositAmount: string, r
             request = simulation.request;
         } catch (simulationError: any) {
             console.warn("ATOM_SIMULATION_FAILED:", simulationError);
+            if (errorLooksLikeAtomAlreadyExists(simulationError)) {
+                const ready =
+                    (await isTermCreatedOnChain(candidate)) ||
+                    (await waitUntilTermCreatedOnChain(candidate, { maxAttempts: 28, delayMs: 320 }));
+                if (ready) {
+                    onProgress?.('Identity already on-chain — reusing it.');
+                    return { hash: '0x0000000000000000000000000000000000000000000000000000000000000000', termId: candidate };
+                }
+            }
             const parsed = parseProtocolError(simulationError);
             // Search for keywords case-insensitively
             const upper = parsed.toUpperCase();
@@ -1929,6 +1930,21 @@ export const createIdentityAtom = async (metadata: any, depositAmount: string, r
         return { hash, termId };
     } catch (error: any) {
         console.error('createIdentityAtom failed:', error?.message || error);
+        try {
+            const { dataHex } = await getFeeProxyAtomParams(metadata, depositAmount);
+            const candidate = await getProtocolAtomIdFromAtomData(dataHex);
+            if (errorLooksLikeAtomAlreadyExists(error)) {
+                const ready =
+                    (await isTermCreatedOnChain(candidate)) ||
+                    (await waitUntilTermCreatedOnChain(candidate, { maxAttempts: 28, delayMs: 320 }));
+                if (ready) {
+                    onProgress?.('Identity already on-chain — reusing it.');
+                    return { hash: '0x0000000000000000000000000000000000000000000000000000000000000000', termId: candidate };
+                }
+            }
+        } catch {
+            /* fall through */
+        }
         const parsed = parseProtocolError(error);
         const upper = parsed.toUpperCase();
         if (upper.includes("REVERTED") || upper.includes("BALANCE") || upper.includes("FEE")) {
@@ -2092,13 +2108,27 @@ export async function batchEnsureAtomTermIds(
             if (!errorLooksLikeAtomAlreadyExists(e)) throw e;
             onProgress?.('Atom batch reported duplicates — confirming anchors on-chain…');
         }
+        const jobByKey = new Map(orderedUnique.map((j) => [atomRefJobKey(j.ref, j.depositTrust), j]));
         for (const b of byDataHex.values()) {
             const tid = await getProtocolAtomIdFromAtomData(b.dataHex);
-            const ok = await waitUntilTermCreatedOnChain(tid, { maxAttempts: 28, delayMs: 320 });
-            if (!ok) {
-                throw new Error(`Atom ${b.dataHex.slice(0, 12)}… did not appear on-chain — wait and retry.`);
+            let ok = await waitUntilTermCreatedOnChain(tid, { maxAttempts: 28, delayMs: 320 });
+            if (ok) {
+                for (const k of b.keys) out.set(k, tid);
+                continue;
             }
-            for (const k of b.keys) out.set(k, tid);
+            onProgress?.('Confirming member atoms one-by-one…');
+            for (const k of b.keys) {
+                if (out.has(k)) continue;
+                const job = jobByKey.get(k);
+                if (!job) continue;
+                const resolved = await resolveAtomReferenceToTermId(
+                    job.ref,
+                    job.depositTrust,
+                    receiver,
+                    onProgress,
+                );
+                out.set(k, resolved.termId);
+            }
         }
     }
 
@@ -2397,6 +2427,8 @@ export type SemanticTripleBatchInput = {
  * Single-transaction claim write batch via FeeProxy.createTriples.
  * All ids must be valid bytes32 term ids (existing atoms/terms).
  */
+const ZERO_TX_HASH = '0x0000000000000000000000000000000000000000000000000000000000000000' as const;
+
 export const createSemanticTriplesBatch = async (
   triples: SemanticTripleBatchInput[],
   receiver: string,
@@ -2407,12 +2439,38 @@ export const createSemanticTriplesBatch = async (
   const provider = getProvider();
   if (!provider) throw new Error('Wallet not connected');
 
-  const subjectIds = triples.map((t) => padTermId(t.subjectId));
-  const predicateIds = triples.map((t) => padTermId(t.predicateId));
-  const objectIds = triples.map((t) => padTermId(t.objectId));
-  const assets = triples.map((t) => t.assetsWei);
+  const pending: SemanticTripleBatchInput[] = [];
+  for (const t of triples) {
+    const sId = padTermId(t.subjectId);
+    const pId = padTermId(t.predicateId);
+    const oId = padTermId(t.objectId);
+    const tripleId = calculateTripleId(sId, pId, oId);
+    if (await isTermCreatedOnChain(tripleId)) {
+      onProgress?.('Claim already on-chain — reusing existing vault.');
+      continue;
+    }
+    if (await waitUntilTermCreatedOnChain(tripleId, { maxAttempts: 5, delayMs: 240 })) {
+      onProgress?.('Claim registered — reusing existing vault.');
+      continue;
+    }
+    pending.push(t);
+  }
+
+  if (!pending.length) {
+    onProgress?.(
+      triples.length > 1
+        ? `All ${triples.length} claims already on-chain — nothing new to create.`
+        : 'Claim already on-chain — nothing new to create.',
+    );
+    return ZERO_TX_HASH;
+  }
+
+  const subjectIds = pending.map((t) => padTermId(t.subjectId));
+  const predicateIds = pending.map((t) => padTermId(t.predicateId));
+  const objectIds = pending.map((t) => padTermId(t.objectId));
+  const assets = pending.map((t) => t.assetsWei);
   const totalDeposit = assets.reduce((a, b) => a + b, 0n);
-  const tripleCount = BigInt(triples.length);
+  const tripleCount = BigInt(pending.length);
 
   for (const a of assets) {
     if (a < CURVE_OFFSET) {
@@ -2453,15 +2511,15 @@ export const createSemanticTriplesBatch = async (
     totalCost = (multiVaultCost * 115n) / 100n;
   }
 
-  onProgress?.(`Preparing ${triples.length} claim writes…`);
+  onProgress?.(`Preparing ${pending.length} claim write(s)…`);
   onProgress?.(`Total value: ${formatEther(totalCost)} ${CURRENCY_SYMBOL}`);
 
-  for (let i = 0; i < triples.length; i++) {
-    const t = triples[i]!;
+  for (let i = 0; i < pending.length; i++) {
+    const t = pending[i]!;
     const { ok, missing } = await validateTripleAtomsExist(t.subjectId, t.predicateId, t.objectId);
     if (!ok) {
       throw new Error(
-        `Triple row ${i + 1}: atom(s) not on-chain yet (${missing.join(', ')}). Wait for sync or verify IDs.`
+        `Triple row ${i + 1}: atom(s) not on-chain yet — ${missing.join(', ')}. Wait for sync or verify IDs.`
       );
     }
   }
@@ -2484,11 +2542,59 @@ export const createSemanticTriplesBatch = async (
     } as any);
     request = simulation.request;
   } catch (e: any) {
+    if (errorLooksLikeTripleAlreadyExists(e)) {
+      onProgress?.('Claims reported duplicates — confirming on-chain…');
+      for (const t of pending) {
+        const tripleId = calculateTripleId(
+          padTermId(t.subjectId),
+          padTermId(t.predicateId),
+          padTermId(t.objectId),
+        );
+        const ready =
+          (await isTermCreatedOnChain(tripleId)) ||
+          (await waitUntilTermCreatedOnChain(tripleId, { maxAttempts: 28, delayMs: 320 }));
+        if (!ready) {
+          throw new Error(
+            `Claim ${tripleId.slice(0, 12)}… did not appear on-chain after duplicate — wait and retry.`,
+          );
+        }
+      }
+      onProgress?.('Claims already on-chain — reusing existing vaults.');
+      window.dispatchEvent(new Event('local-tx-updated'));
+      return ZERO_TX_HASH;
+    }
     const parsed = parseProtocolError(e);
     throw new Error(parsed || 'Batch simulation failed');
   }
 
-  const hash = await walletClient.writeContract(request);
+  let hash: `0x${string}`;
+  try {
+    hash = await walletClient.writeContract(request);
+  } catch (e: any) {
+    if (errorLooksLikeTripleAlreadyExists(e)) {
+      onProgress?.('Claims reported duplicates — confirming on-chain…');
+      for (const t of pending) {
+        const tripleId = calculateTripleId(
+          padTermId(t.subjectId),
+          padTermId(t.predicateId),
+          padTermId(t.objectId),
+        );
+        const ready =
+          (await isTermCreatedOnChain(tripleId)) ||
+          (await waitUntilTermCreatedOnChain(tripleId, { maxAttempts: 28, delayMs: 320 }));
+        if (!ready) {
+          throw new Error(
+            `Claim ${tripleId.slice(0, 12)}… did not appear on-chain after duplicate — wait and retry.`,
+          );
+        }
+      }
+      onProgress?.('Claims already on-chain — reusing existing vaults.');
+      window.dispatchEvent(new Event('local-tx-updated'));
+      return ZERO_TX_HASH;
+    }
+    const parsed = parseProtocolError(e);
+    throw new Error(parsed || 'Batch submit failed');
+  }
   window.dispatchEvent(new Event('local-tx-updated'));
   return hash;
 };


### PR DESCRIPTION
Redesign Compare with clearer typography and side-by-side peer panels; batch FeeProxy deposit scans so peer similarity loads from one graph bundle instead of per-wallet refetches. Wire mint to wallet stakes, drop Arena conviction cart on climb, and tighten Signal/Skill copy and on-chain helpers.