### PR TITLE
fix: repair invalid UTF-8 (· separators) blocking the Nixpacks website build

### DIFF
--- a/components/ActivityRow.tsx
+++ b/components/ActivityRow.tsx
@@ -148,7 +148,7 @@ const ActivityRow: React.FC<ActivityRowProps> = ({ event }) => {
                         color: colorHex,
                     }}
                 >
-                    {isWhale ? `Large Â/ ${statusLabel}` : statusLabel}
+                    {isWhale ? `Large Â· ${statusLabel}` : statusLabel}
                 </div>
                 
                 {!(isAtomCreation || isTripleCreation) && (
@@ -160,7 +160,7 @@ const ActivityRow: React.FC<ActivityRowProps> = ({ event }) => {
                     </div>
                 )}
 
-                <span className="text-slate-600 font-sans text-[10px] px-0.5" aria-hidden>Â/</span>
+                <span className="text-slate-600 font-sans text-[10px] px-0.5" aria-hidden>Â·</span>
 
                 <div className="flex items-center gap-2 bg-white/[0.04] border border-white/[0.08] px-2 py-1.5 rounded-xl hover:border-white/15 transition-all duration-300 group/target cursor-pointer min-w-0 max-w-full">
                     <div className="w-4 h-4 sm:w-[18px] sm:h-[18px] rounded-md bg-black/50 flex items-center justify-center overflow-hidden border border-white/10 shrink-0 group-hover:scale-105 transition-transform">

--- a/components/ArenaBatchReviewModal.tsx
+++ b/components/ArenaBatchReviewModal.tsx
@@ -185,7 +185,7 @@ const ArenaBatchReviewModal: React.FC<Props> = ({
                     Conviction cart
                   </h2>
                   <p className="text-[10px] text-slate-500 font-mono mt-1 truncate">
-                    Review batch Â/ <span className="text-intuition-primary/90">{contextSuffix}</span>
+                    Review batch Â· <span className="text-intuition-primary/90">{contextSuffix}</span>
                   </p>
                 </div>
               </div>
@@ -286,7 +286,7 @@ const ArenaBatchReviewModal: React.FC<Props> = ({
                           <p className="text-[9px] text-slate-500 mt-0.5 font-mono uppercase tracking-wide truncate">
                             {row.item.pairKind}
                             {row.sourceListTitle ? (
-                              <span className="text-slate-600 normal-case"> Â/ {row.sourceListTitle}</span>
+                              <span className="text-slate-600 normal-case"> Â· {row.sourceListTitle}</span>
                             ) : null}
                           </p>
                           <p className="text-[10px] font-mono font-bold mt-1.5 text-intuition-primary tabular-nums">
@@ -297,7 +297,7 @@ const ArenaBatchReviewModal: React.FC<Props> = ({
                               </span>
                             ) : null}
                             {row.units > 1 ? (
-                              <span className="text-slate-500 font-normal"> Â/ {stakeN.toFixed(2)} Ã— {row.units}</span>
+                              <span className="text-slate-500 font-normal"> Â· {stakeN.toFixed(2)} Ã— {row.units}</span>
                             ) : null}
                           </p>
                         </div>
@@ -395,7 +395,7 @@ const ArenaBatchReviewModal: React.FC<Props> = ({
                     </span>
                   </div>
                 ) : (
-                  <>Confirm Â/ {trustTotal.toFixed(2)} TRUST</>
+                  <>Confirm Â· {trustTotal.toFixed(2)} TRUST</>
                 )}
               </button>
             </div>

--- a/components/ArenaClimbTerrace.tsx
+++ b/components/ArenaClimbTerrace.tsx
@@ -56,7 +56,7 @@ const ArenaClimbTerrace: React.FC<ArenaClimbTerraceProps> = ({
           }`}
         >
           <Layers size={13} strokeWidth={2.2} className={`shrink-0 ${light ? 'text-intuition-primary' : 'text-intuition-primary'}`} aria-hidden />
-          Review cart Â/ {queuedBatchCount}
+          Review cart Â· {queuedBatchCount}
         </button>
       </div>
     </div>

--- a/components/ArenaCompareModal.tsx
+++ b/components/ArenaCompareModal.tsx
@@ -201,7 +201,7 @@ const ArenaCompareModal: React.FC<Props> = ({ open, onClose, left, right }) => {
                     <div className="flex items-center gap-2.5 px-4 py-3 border-b border-slate-800/90 bg-gradient-to-r from-intuition-primary/10 via-slate-900/80 to-intuition-primary/10">
                       <Swords size={16} className="text-intuition-primary/90 shrink-0" />
                       <span className="text-[11px] font-black uppercase tracking-[0.18em] text-white font-display">Signal breakdown</span>
-                      <span className="text-[9px] text-slate-500 font-mono uppercase tracking-wider hidden sm:inline">Lane A Â/ Lane B</span>
+                      <span className="text-[9px] text-slate-500 font-mono uppercase tracking-wider hidden sm:inline">Lane A Â· Lane B</span>
                     </div>
                     <div className="bg-[#03060a]/90">
                       <ComparisonRow

--- a/components/ArenaMyRankingsPanel.tsx
+++ b/components/ArenaMyRankingsPanel.tsx
@@ -138,7 +138,7 @@ const ArenaMyRankingsPanel: React.FC<{ wallet: string | null }> = ({ wallet }) =
               <Layers className="w-5 h-5 text-intuition-primary" strokeWidth={2} />
             </div>
             <div className="min-w-0">
-              <p className="text-[10px] xl:text-xs font-black text-slate-500 uppercase tracking-[0.28em] mb-1">Arena Â/ Portfolio</p>
+              <p className="text-[10px] xl:text-xs font-black text-slate-500 uppercase tracking-[0.28em] mb-1">Arena Â· Portfolio</p>
               <h2 className="text-xl sm:text-2xl font-black font-display text-white tracking-tight">My ranked lists</h2>
               <p className="text-[13px] text-slate-400 mt-1.5 max-w-2xl leading-relaxed">
                 FeeProxy/MultiVault deposits only â€” your wallet is the{' '}
@@ -289,11 +289,11 @@ function ArenaListOnchainCard({
             <p className="text-[11px] text-slate-500 mt-0.5 flex flex-wrap gap-x-3 gap-y-1">
               <span>
                 <span className="text-intuition-success font-semibold tabular-nums">{group.yesCount}</span>
-                {' yes Â/ '}
+                {' yes Â· '}
                 <span className="text-intuition-danger font-semibold tabular-nums">{group.noCount}</span>
                 {' no'}
               </span>
-              <span className="text-slate-600">Â/</span>
+              <span className="text-slate-600">Â·</span>
               <span className="tabular-nums uppercase tracking-wider">Latest block {group.maxBlock || 'â€”'}</span>
             </p>
             {!expanded && preview.length > 0 ? (
@@ -319,7 +319,7 @@ function ArenaListOnchainCard({
             ) : null}
             {!expanded && group.rows.length > preview.length ? (
               <p className="mt-2 text-[10px] font-medium text-slate-600">
-                +{group.rows.length - preview.length} more Â/ expand for full table
+                +{group.rows.length - preview.length} more Â· expand for full table
               </p>
             ) : null}
           </div>

--- a/components/ArenaRankingPulse.tsx
+++ b/components/ArenaRankingPulse.tsx
@@ -389,7 +389,7 @@ const ArenaRankingPulse: React.FC<Props> = ({ className, variant = 'compact', vi
                         variant === 'explorer' ? 'text-slate-400 font-medium' : 'text-slate-500 font-medium'
                       }
                     >
-                      Â/
+                      Â·
                     </span>{' '}
                     <Link
                       to={climbHrefForListTerm(row.listTermId)}
@@ -428,7 +428,7 @@ const ArenaRankingPulse: React.FC<Props> = ({ className, variant = 'compact', vi
                             className="inline-flex items-center rounded-md border border-slate-500/40 bg-slate-900/90 px-1.5 py-0.5 text-[10px] font-mono font-semibold text-slate-200 text-right max-w-[13rem] sm:max-w-none leading-tight"
                             title="Arena pick credit applies once the indexer attributes the rank. Submit ranks from this browser to store XPDN per tx locally."
                           >
-                            +{ARENA_XP_PER_RANK_PICK} Arena Â/ XPDN
+                            +{ARENA_XP_PER_RANK_PICK} Arena Â· XPDN
                           </span>
                         )
                       ) : null}

--- a/components/ArenaSidebarPanels.tsx
+++ b/components/ArenaSidebarPanels.tsx
@@ -12,7 +12,7 @@ export const ArenaBrowseLaneHud: React.FC<{ laneLabel: string; listCount: number
 }) => (
   <div className="rounded-3xl border border-white/[0.08] bg-black/50 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]">
     <p className="text-[8px] font-mono font-black uppercase tracking-[0.28em] text-[#38e8ff]/85 mb-1">
-      Lane Â/ browse
+      Lane Â· browse
     </p>
     <p className="text-[13px] font-bold text-white truncate leading-tight">{laneLabel}</p>
     <p className="text-[11px] font-mono tabular-nums text-slate-500 mt-2">

--- a/components/ArenaStarredRail.tsx
+++ b/components/ArenaStarredRail.tsx
@@ -82,7 +82,7 @@ const ArenaStarredRail: React.FC<Props> = ({
                     className="flex-1 min-w-0 flex items-center gap-2 px-3 py-2 text-left hover:bg-intuition-primary/[0.06] transition-colors"
                   >
                     <span className="w-7 h-7 rounded-lg bg-black/40 border border-white/10 flex items-center justify-center text-[11px] font-black text-intuition-primary/90 shrink-0">
-                      {row.listGlyph?.slice(0, 2) ?? 'Â/'}
+                      {row.listGlyph?.slice(0, 2) ?? 'Â·'}
                     </span>
                     <span className="min-w-0 flex-1">
                       <span className="block text-[11px] font-bold text-slate-100 truncate leading-tight">{row.title}</span>

--- a/components/CreateModal.tsx
+++ b/components/CreateModal.tsx
@@ -384,7 +384,7 @@ const CreateModal: React.FC<CreateModalProps> = ({ isOpen, onClose }) => {
                     {view === 'IDENTITY_CREATOR' && 'New atom'}
                 </h2>
                 <div className="text-xs text-slate-500">
-                    {view === 'IDLE' && 'Atoms are atoms Â/ Claims are claims'}
+                    {view === 'IDLE' && 'Atoms are atoms Â· Claims are claims'}
                     {view === 'CLAIM_OVERVIEW' && 'Subject + predicate + object, then deposit'}
                     {view === 'SELECTOR' && 'Search or create a new atom'}
                     {view === 'IDENTITY_CREATOR' && 'A person, org, thing, or account on the graph'}
@@ -590,7 +590,7 @@ const CreateModal: React.FC<CreateModalProps> = ({ isOpen, onClose }) => {
              <div className="w-1.5 h-1.5 rounded-full bg-intuition-success animate-pulse shadow-[0_0_8px_#00ff9d]" />
              <span className="text-xs text-slate-500">Ready to create on IntuRank</span>
            </div>
-           <span className="text-[11px] text-slate-600 hidden sm:inline">Â/</span>
+           <span className="text-[11px] text-slate-600 hidden sm:inline">Â·</span>
            <span className="text-[11px] text-slate-600">Your wallet signs each transaction</span>
         </div>
       </div>

--- a/components/HomeGameBoard.tsx
+++ b/components/HomeGameBoard.tsx
@@ -167,7 +167,7 @@ const GameRow: React.FC<{
           <p className="mt-1 max-w-xl text-[12px] text-slate-500 leading-relaxed">{section.subtitle}</p>
         </div>
         <span className="mx-auto shrink-0 rounded-lg border border-white/[0.08] bg-white/[0.03] px-2.5 py-1 font-mono text-[9px] font-bold uppercase tracking-[0.18em] text-slate-300 sm:mx-0">
-          ~{section.lists.reduce((s, L) => s + getArenaListConstituents(L), 0).toLocaleString()} pick slots Â/{' '}
+          ~{section.lists.reduce((s, L) => s + getArenaListConstituents(L), 0).toLocaleString()} pick slots Â·{' '}
           <span className="text-slate-500">{section.lists.length}</span> contest{section.lists.length === 1 ? '' : 's'}
         </span>
       </div>

--- a/components/IntuRankXpBadge.tsx
+++ b/components/IntuRankXpBadge.tsx
@@ -52,7 +52,7 @@ export interface IntuRankXpBadgeProps {
   size?: IntuRankXpBadgeSize;
   /** Optional rank number from the leaderboard — rendered as a small chip. */
   rank?: number | null;
-  /** When true, hides the breakdown line (Arena �/ Activity). Useful in tight spaces. */
+  /** When true, hides the breakdown line (Arena · Activity). Useful in tight spaces. */
   compact?: boolean;
   className?: string;
   /** Shown when the connected wallet hasn't loaded yet — keeps layout stable. */
@@ -184,7 +184,7 @@ export const IntuRankXpBadge: React.FC<IntuRankXpBadgeProps> = ({
             <span className={light ? 'text-sky-700' : 'text-intuition-primary/85'}>
               Arena {arenaXp.toLocaleString()}
             </span>
-            <span className="text-slate-600 mx-1.5">�/</span>
+            <span className="text-slate-600 mx-1.5">·</span>
             <span className={light ? 'text-amber-700' : 'text-amber-300/85'}>
               Activity {activityXp.toLocaleString()}
             </span>

--- a/components/ProfileShareCard.tsx
+++ b/components/ProfileShareCard.tsx
@@ -227,7 +227,7 @@ export default function ProfileShareCard({
               {arenaXpTotal > 0 || protocolXpTotal > 0 ? (
                 <p className="mt-1 font-mono text-[10px] sm:text-[11px] font-semibold text-slate-400 antialiased [text-rendering:geometricPrecision]">
                   <span className="text-intuition-primary/85">Arena {arenaXpTotal.toLocaleString()}</span>
-                  <span className="text-slate-600 mx-1.5">Â/</span>
+                  <span className="text-slate-600 mx-1.5">Â·</span>
                   <span className="text-amber-300/85">Activity {protocolXpTotal.toLocaleString()}</span>
                 </p>
               ) : null}

--- a/components/Season2LeaderboardPanel.tsx
+++ b/components/Season2LeaderboardPanel.tsx
@@ -406,7 +406,7 @@ export const Season2LeaderboardPanel: React.FC<{
                 <Link to={HREF_NETWORK_PNL} onClick={playClick} className="text-slate-400 hover:text-slate-300">
                   All-time
                 </Link>
-                {' Â/ '}
+                {' Â· '}
                 <Link
                   to="/markets/atoms"
                   onClick={playClick}
@@ -451,7 +451,7 @@ export const Season2LeaderboardPanel: React.FC<{
                     <span className="font-medium text-slate-100 truncate w-full">
                       {selectedEpoch.label}
                       {epochIsLiveNow(selectedEpoch) || epochIsCurrent(selectedEpoch) ? (
-                        <span className="text-amber-400/90 font-normal"> Â/ Current</span>
+                        <span className="text-amber-400/90 font-normal"> Â· Current</span>
                       ) : null}
                     </span>
                     <span className="text-[11px] text-slate-500 truncate w-full mt-0.5">{selectedEpoch.range}</span>
@@ -481,7 +481,7 @@ export const Season2LeaderboardPanel: React.FC<{
                         <span className="block truncate">
                           {epoch.label}
                           {epochIsLiveNow(epoch) || epochIsCurrent(epoch) ? (
-                            <span className="text-amber-400/80"> Â/ Current</span>
+                            <span className="text-amber-400/80"> Â· Current</span>
                           ) : null}
                         </span>
                         <span className="block text-[10px] text-slate-500 truncate mt-0.5">{epoch.range}</span>
@@ -598,7 +598,7 @@ export const Season2LeaderboardPanel: React.FC<{
                             {u.display}
                           </span>
                           <span className="text-slate-600 shrink-0" aria-hidden>
-                            Â/
+                            Â·
                           </span>
                           <span
                             className={`min-w-0 font-semibold tabular-nums ${p.value >= 0 ? 'text-intuition-success' : 'text-red-400'}`}
@@ -620,7 +620,7 @@ export const Season2LeaderboardPanel: React.FC<{
                           {formatPctPretty(src.unrealized_pnl_pct)}
                         </span>
                         <span className="text-slate-600 shrink-0" aria-hidden>
-                          Â/
+                          Â·
                         </span>
                         <span
                           className={`min-w-0 font-semibold tabular-nums ${pctTextClass(rPct)}`}

--- a/components/SignalFeed.tsx
+++ b/components/SignalFeed.tsx
@@ -1,5 +1,5 @@
 /**
- * Signal — Pulse (stance queue + markets) �/ Vouch (on-chain name claims).
+ * Signal — Pulse (stance queue + markets) · Vouch (on-chain name claims).
  */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
@@ -537,7 +537,7 @@ const SignalFeed: React.FC<Props> = ({ className, viewerAddress }) => {
         unitsTrust: DEFAULT_STAKE_UNITS,
       });
       if (!result.applied) return;
-      if (result.reason === 'added') toast.success(`Queued �/ ${stance === 'stand' ? 'Support' : 'Oppose'}`);
+      if (result.reason === 'added') toast.success(`Queued · ${stance === 'stand' ? 'Support' : 'Oppose'}`);
       else if (result.reason === 'flipped')
         toast.info(
           `${stance === 'stand' ? 'Support' : 'Oppose'} queued — submit from the conviction cart (new deposit, not an instant flip).`,
@@ -566,8 +566,8 @@ const SignalFeed: React.FC<Props> = ({ className, viewerAddress }) => {
         if (result.reason === 'self') toast.info("Can't vouch for your own wallet.");
         return;
       }
-      if (result.reason === 'added') toast.success(`Queued vouch �/ ${row.label}`);
-      else if (result.reason === 'removed') toast.info(`Removed �/ ${row.label}`);
+      if (result.reason === 'added') toast.success(`Queued vouch · ${row.label}`);
+      else if (result.reason === 'removed') toast.info(`Removed · ${row.label}`);
     },
     [viewerAddress],
   );
@@ -599,7 +599,7 @@ const SignalFeed: React.FC<Props> = ({ className, viewerAddress }) => {
       } catch {
         /* parseEther / award edge cases — tx still succeeded */
       }
-      toast.success(`Submitted �/ ${hash.slice(0, 12)}…`);
+      toast.success(`Submitted · ${hash.slice(0, 12)}…`);
       clearSignalVouches(viewerAddress);
       setVouchTick((n) => n + 1);
       void loadNamedBundle();
@@ -643,9 +643,9 @@ const SignalFeed: React.FC<Props> = ({ className, viewerAddress }) => {
           const side = p.stance === 'stand' ? 'Support' : 'Oppose';
           const lab = p.objectLabel.trim();
           const short = lab.length > 36 ? `${lab.slice(0, 34)}…` : lab;
-          return `${side} �/ “${short}”`;
+          return `${side} · “${short}”`;
         })
-        .join(' �/ ');
+        .join(' · ');
       try {
         playSuccess();
       } catch {
@@ -654,7 +654,7 @@ const SignalFeed: React.FC<Props> = ({ className, viewerAddress }) => {
       setSignalBatchSuccess({
         itemCount: picks.length,
         trustLabel: formatEther(totalWei),
-        themeShort: 'Signal �/ Pulse',
+        themeShort: 'Signal · Pulse',
         contextSuffix: `${picks.length === 1 ? 'vault stake' : `${picks.length} vault stakes`}`,
         humanLine,
         ...(activityXpDelta > 0 ? { activityXpEarned: activityXpDelta } : {}),
@@ -732,7 +732,7 @@ const SignalFeed: React.FC<Props> = ({ className, viewerAddress }) => {
           </div>
           <div className="min-w-0">
             <p className="text-[11px] font-mono font-black uppercase tracking-[0.28em] text-cyan-200">
-              IntuRank �/ Signal
+              IntuRank · Signal
             </p>
             <p className="text-[13px] text-slate-200 leading-snug mt-0.5">
               Queue Pulse stances, then open <strong className="text-cyan-300/95">Review cart</strong> below — same flow as the Arena conviction cart.
@@ -887,7 +887,7 @@ const SignalFeed: React.FC<Props> = ({ className, viewerAddress }) => {
                     <p className="text-[12px] font-semibold text-slate-100 tabular-nums truncate">
                       <span className="text-cyan-200 font-bold">{totalQueuedTrustUnits.toFixed(2)}</span>
                       <span className="text-slate-500 font-normal"> TRUST</span>
-                      <span className="text-slate-600 mx-1">�/</span>
+                      <span className="text-slate-600 mx-1">·</span>
                       <span className="text-slate-400 font-normal">
                         {stanceQueue.length} claim{stanceQueue.length === 1 ? '' : 's'}
                       </span>
@@ -1391,7 +1391,7 @@ const PulseLane: React.FC<{
         {heroAndPills}
         <div className="flex items-center justify-between gap-2 px-1">
           <p className="text-[12px] text-slate-300">
-            <strong className="text-white tabular-nums">{meStances.length}</strong> stake{meStances.length === 1 ? '' : 's'} �/
+            <strong className="text-white tabular-nums">{meStances.length}</strong> stake{meStances.length === 1 ? '' : 's'} ·
             <span className="text-slate-400"> showing {start + 1}–{start + pageRows.length}</span>
           </p>
           <Link
@@ -1436,7 +1436,7 @@ const PulseLane: React.FC<{
                   </div>
                   <p className="text-[12px] text-slate-200 mt-1 font-mono">
                     <span className="tabular-nums text-white">{fmtTrust(it.trustAmount)}T</span>
-                    <span className="text-slate-500 mx-1.5">�/</span>
+                    <span className="text-slate-500 mx-1.5">·</span>
                     <span
                       className={`inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-[10px] font-black uppercase tracking-wider border ${
                         it.support
@@ -1684,7 +1684,7 @@ const PulseLane: React.FC<{
 };
 
 /* -------------------------------------------------------------------------- */
-/* Pulse �/ Identity atom cards — portal-style rail (teal tags + stake + gold thumbs)            */
+/* Pulse · Identity atom cards — portal-style rail (teal tags + stake + gold thumbs)            */
 /* -------------------------------------------------------------------------- */
 
 /** Hide redundant “has tag” line; show predicate when it adds meaning (graph-driven). */
@@ -1752,8 +1752,8 @@ const PulseAtomTagSection: React.FC<{
     rail === 'yours'
       ? 'Your atoms'
       : atomTone === 'crowd'
-        ? 'Atoms �/ live order'
-        : 'Atoms �/ curated heat';
+        ? 'Atoms · live order'
+        : 'Atoms · curated heat';
 
   const gridClass = 'grid grid-cols-1 lg:grid-cols-2 gap-4 items-start';
 
@@ -1868,11 +1868,11 @@ const PulseAtomTagSection: React.FC<{
           {atomsHeading}
           {atomTone === 'crowd' ? (
             <span className="block text-[10px] font-semibold normal-case tracking-normal text-amber-200/85 mt-0.5">
-              Crowd-weighted �/ same heat rail as Hot (amber → violet → red)
+              Crowd-weighted · same heat rail as Hot (amber → violet → red)
             </span>
           ) : atomTone === 'hot' ? (
             <span className="block text-[10px] font-semibold normal-case tracking-normal text-amber-200/85 mt-0.5">
-              Curated spotlight �/ gold rail
+              Curated spotlight · gold rail
             </span>
           ) : null}
         </h3>
@@ -2318,7 +2318,7 @@ const VouchLane: React.FC<{
               Queue trust for the handles below — submit the whole batch from the bar when you&rsquo;re ready.
             </p>
             <p className="text-[12px] font-mono uppercase tracking-[0.16em] text-slate-300 mt-2">
-              {sorted.length} names �/ heavier vaults first
+              {sorted.length} names · heavier vaults first
             </p>
           </div>
         </div>
@@ -2341,7 +2341,7 @@ const VouchLane: React.FC<{
           const metaLine = i.walletId
             ? shortAddress(i.walletId)
             : i.termId
-              ? `${shortAddress(i.termId)} �/ vault`
+              ? `${shortAddress(i.termId)} · vault`
               : shortAddress(i.rowKey);
           return (
             <li

--- a/components/SignalStanceCartModal.tsx
+++ b/components/SignalStanceCartModal.tsx
@@ -131,8 +131,8 @@ const SignalStanceCartModal: React.FC<Props> = ({
                     Conviction cart
                   </h2>
                   <p className="text-[10px] text-slate-500 font-mono mt-1 truncate">
-                    Pulse Â/ <span className="text-intuition-primary/90">{picks.length} claim{picks.length === 1 ? '' : 's'}</span>
-                    <span className="text-slate-600"> Â/ </span>
+                    Pulse Â· <span className="text-intuition-primary/90">{picks.length} claim{picks.length === 1 ? '' : 's'}</span>
+                    <span className="text-slate-600"> Â· </span>
                     <span className="text-amber-200/90 tabular-nums">{trustTotalLabel} TRUST</span>
                   </p>
                 </div>
@@ -261,7 +261,7 @@ const SignalStanceCartModal: React.FC<Props> = ({
             </div>
 
             <p className="px-4 pb-2 text-[10px] text-slate-500 leading-snug shrink-0 z-10">
-              One wallet signature sends the whole cart in a single batch deposit Â/ counts are{' '}
+              One wallet signature sends the whole cart in a single batch deposit Â· counts are{' '}
               <span className="text-slate-400">triples</span>, not atoms.
             </p>
 
@@ -289,8 +289,8 @@ const SignalStanceCartModal: React.FC<Props> = ({
                 ) : (
                   <>
                     <Shield size={18} strokeWidth={2.2} className="shrink-0 opacity-90" />
-                    Confirm Â/ {trustTotalLabel} TRUST
-                    {picks.length > 1 ? ` Â/ ${picks.length} stakes` : ''} Â/ {batchTxCount}&nbsp;tx
+                    Confirm Â· {trustTotalLabel} TRUST
+                    {picks.length > 1 ? ` Â· ${picks.length} stakes` : ''} Â· {batchTxCount}&nbsp;tx
                   </>
                 )}
               </motion.button>

--- a/components/SkillChat.tsx
+++ b/components/SkillChat.tsx
@@ -1266,7 +1266,7 @@ const SkillChat: React.FC<SkillChatProps> = ({ className = '' }) => {
                     </div>
                     <div className="flex flex-col min-w-0">
                         <span className="text-sm font-semibold text-white font-sans tracking-tight leading-tight">Skill agent</span>
-                        <span className="text-[11px] text-slate-500 font-sans leading-tight mt-0.5">{NETWORK_NAME} Â/ chain {CHAIN_ID}</span>
+                        <span className="text-[11px] text-slate-500 font-sans leading-tight mt-0.5">{NETWORK_NAME} Â· chain {CHAIN_ID}</span>
                     </div>
                 </div>
                 <button
@@ -1816,7 +1816,7 @@ const SkillChat: React.FC<SkillChatProps> = ({ className = '' }) => {
                 <div className="mt-1.5 flex flex-wrap items-center justify-between gap-2 px-0.5">
                     <p className="text-[10px] text-slate-600 font-sans select-none">
                         <kbd className="rounded border border-white/10 bg-white/[0.04] px-1 py-px font-mono text-[9px] text-slate-500">Enter</kbd>
-                        {' '}to send Â/{' '}
+                        {' '}to send Â·{' '}
                         <kbd className="rounded border border-white/10 bg-white/[0.04] px-1 py-px font-mono text-[9px] text-slate-500">Shift</kbd>
                         +
                         <kbd className="rounded border border-white/10 bg-white/[0.04] px-1 py-px font-mono text-[9px] text-slate-500">Enter</kbd>

--- a/components/arenaFlow/ArenaCompareView.tsx
+++ b/components/arenaFlow/ArenaCompareView.tsx
@@ -96,7 +96,7 @@ function peerDisplayName(label: string, address: string): string {
 }
 
 /**
- * Step 3 Â/ Similarity. Two-column composition (deck preview | similarity rail)
+ * Step 3 Â· Similarity. Two-column composition (deck preview | similarity rail)
  * with an honest peer list below. All numbers come from on-chain claims; if
  * the contest is off-chain or no overlap exists, the section is hidden or
  * clearly labelled when missing so nothing is fabricated.
@@ -172,7 +172,7 @@ export const ArenaCompareView: React.FC<Props> = ({
 
   return (
     <ArenaContestStepShell
-      chromeTitle={`Compare Â/ ${palette.label}`}
+      chromeTitle={`Compare Â· ${palette.label}`}
       maxWidthClass="max-w-none"
       innerPaddingClassName="px-3 py-5 sm:px-4 sm:py-6 md:px-5 md:py-7 lg:px-6 xl:px-8"
     >
@@ -188,7 +188,7 @@ export const ArenaCompareView: React.FC<Props> = ({
           className="font-mono text-[10px] font-black uppercase tracking-[0.32em]"
           style={{ color: palette.hex }}
         >
-          Step 3 Â/ Compare Â/ {palette.label}
+          Step 3 Â· Compare Â· {palette.label}
         </p>
         <h1 className="mt-2 font-display text-2xl font-black leading-[1.05] tracking-tight text-white sm:text-3xl">
           Your deck vs the board
@@ -883,7 +883,7 @@ const PeerList: React.FC<{
             Arena Explorer
           </Link>
           <span className="text-slate-600" aria-hidden>
-            Â/
+            Â·
           </span>
           <Link
             to="/portfolio#arena-rankings"
@@ -1081,7 +1081,7 @@ const PeerRow: React.FC<{
           {expanded && canExpand ? (
             <div className="border-t border-white/[0.06] px-4 pb-5 pt-4 sm:px-6">
               <p className="font-mono text-xs font-black uppercase tracking-[0.18em] text-white sm:text-sm">
-                Side-by-side Â/ you vs {name}
+                Side-by-side Â· you vs {name}
               </p>
               <p className="mt-1 text-sm font-medium text-slate-200">
                 Your deck is above â€” this table only lines up shared picks.
@@ -1097,9 +1097,9 @@ const PeerRow: React.FC<{
                     style={{ borderColor: `${palette.hex}33`, background: `${palette.hex}10` }}
                   >
                     <span>Pick</span>
-                    <span className="text-center">You Â/ {CURRENCY_SYMBOL}</span>
+                    <span className="text-center">You Â· {CURRENCY_SYMBOL}</span>
                     <span className="text-center" style={{ color: palette.hex }}>
-                      Them Â/ {CURRENCY_SYMBOL}
+                      Them Â· {CURRENCY_SYMBOL}
                     </span>
                     <span className="text-right">Match</span>
                   </div>

--- a/components/arenaFlow/ArenaCreateCardModal.tsx
+++ b/components/arenaFlow/ArenaCreateCardModal.tsx
@@ -145,7 +145,7 @@ export const ArenaCreateCardModal: React.FC<Props> = ({
             >
               <div className="min-w-0">
                 <p className="font-mono text-[9px] font-black uppercase tracking-[0.22em] opacity-80">
-                  {palette.label} Â/ Add to deck
+                  {palette.label} Â· Add to deck
                 </p>
                 <h2
                   id="arena-create-card-title"
@@ -288,10 +288,10 @@ const FormBody: React.FC<FormProps> = ({
         />
       </Field>
 
-      <Field label="Subtitle" hint={`${subtitle.length}/${MAX_SUBTITLE} Â/ optional`}>
+      <Field label="Subtitle" hint={`${subtitle.length}/${MAX_SUBTITLE} Â· optional`}>
         <input
           type="text"
-          placeholder="e.g. Ecosystem Â/ community lead"
+          placeholder="e.g. Ecosystem Â· community lead"
           maxLength={MAX_SUBTITLE}
           value={subtitle}
           onChange={(e) => setSubtitle(e.target.value)}
@@ -301,7 +301,7 @@ const FormBody: React.FC<FormProps> = ({
 
       <Field
         label="Image URL"
-        hint="optional Â/ http(s)://"
+        hint="optional Â· http(s)://"
         error={touched && error?.field === 'image' ? error.message : null}
       >
         <div className="flex items-stretch gap-2">

--- a/components/arenaFlow/ArenaPromoteContestModal.tsx
+++ b/components/arenaFlow/ArenaPromoteContestModal.tsx
@@ -256,7 +256,7 @@ export const ArenaPromoteContestModal: React.FC<Props> = ({
             >
               <div className="min-w-0">
                 <p className="font-mono text-[9px] font-black uppercase tracking-[0.22em] opacity-85">
-                  {palette.label} Â/ Promote contest
+                  {palette.label} Â· Promote contest
                 </p>
                 <h2
                   id="arena-promote-title"
@@ -489,7 +489,7 @@ const FormView: React.FC<{
       </footer>
 
       <p className="mt-3 text-center font-mono text-[10px] uppercase tracking-wider text-slate-600">
-        Min deposit / leg Â/ {minDeposit} {CURRENCY_SYMBOL}
+        Min deposit / leg Â· {minDeposit} {CURRENCY_SYMBOL}
       </p>
     </div>
   );

--- a/components/arenaFlow/ArenaRankDeck.tsx
+++ b/components/arenaFlow/ArenaRankDeck.tsx
@@ -235,7 +235,7 @@ const RankRow: React.FC<RowProps> = ({
               className="mt-1.5 font-mono text-[11px] font-bold tabular-nums sm:hidden"
               style={{ color: deck.hex }}
             >
-              {trustAmt} TRUST <span className="text-slate-500">Â/ Ã—{u}</span>
+              {trustAmt} TRUST <span className="text-slate-500">Â· Ã—{u}</span>
             </p>
           </div>
         </div>
@@ -426,7 +426,7 @@ const RankRow: React.FC<RowProps> = ({
 /* ============================== Page ============================== */
 
 /**
- * Step 2 Â/ Rank â€” 2-column composition: vertical leaderboard list on the left,
+ * Step 2 Â· Rank â€” 2-column composition: vertical leaderboard list on the left,
  * a rich rail (podium summary + stake distribution + action buttons) on the right
  * that fills vertical space regardless of how many cards are in the deck. Drag
  * works on the dedicated grip handle (single Y axis, no grid).
@@ -498,7 +498,7 @@ export const ArenaRankDeck: React.FC<Props> = ({
 
   return (
     <ArenaContestStepShell
-      chromeTitle={`Ranking Â/ ${deck.label}`}
+      chromeTitle={`Ranking Â· ${deck.label}`}
       maxWidthClass="max-w-none"
       innerPaddingClassName="px-3 py-5 sm:px-4 sm:py-6 md:px-5 md:py-7 lg:px-6 xl:px-8"
     >
@@ -508,7 +508,7 @@ export const ArenaRankDeck: React.FC<Props> = ({
           className="font-mono text-[10px] font-black uppercase tracking-[0.32em]"
           style={{ color: deck.hex }}
         >
-          Step 2 Â/ Rank Â/ {deck.label}
+          Step 2 Â· Rank Â· {deck.label}
         </p>
         <h2 className="font-display text-2xl font-black leading-tight tracking-tight text-white sm:text-3xl md:text-[2rem]">
           Order & weight your deck
@@ -531,7 +531,7 @@ export const ArenaRankDeck: React.FC<Props> = ({
               {typeof poolParticipantCount === 'number' ? (
                 <span className="inline-flex items-center gap-1.5 tabular-nums">
                   <Users className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
-                  Pool Â/ {poolParticipantCount} pick{poolParticipantCount === 1 ? '' : 's'}
+                  Pool Â· {poolParticipantCount} pick{poolParticipantCount === 1 ? '' : 's'}
                 </span>
               ) : null}
               {(listStakersLoading || listStakersCount != null) && (
@@ -620,7 +620,7 @@ export const ArenaRankDeck: React.FC<Props> = ({
                 <Plus className="h-5 w-5" strokeWidth={2.6} />
               </span>
               <span className="text-[11px] font-bold uppercase tracking-wider">Create a new card</span>
-              <span className="text-[10px] text-slate-500">Â/ add an item to the list</span>
+              <span className="text-[10px] text-slate-500">Â· add an item to the list</span>
             </button>
           ) : null}
         </div>
@@ -677,7 +677,7 @@ export const ArenaRankDeck: React.FC<Props> = ({
                 Stake distribution
               </p>
               <span className="font-mono text-[9px] font-bold uppercase tracking-widest text-slate-600">
-                {totalUnits} units Â/ strongest first
+                {totalUnits} units Â· strongest first
               </span>
             </div>
             {stakePerItemSorted.length === 0 ? (
@@ -694,7 +694,7 @@ export const ArenaRankDeck: React.FC<Props> = ({
                         <span className="truncate text-[11px] font-semibold text-slate-200">{r.label}</span>
                         <span className="font-mono text-[10px] font-bold tabular-nums text-slate-500">
                           {formatTrust(base, r.units)}{' '}
-                          <span className="text-slate-600">Â/ Ã—{r.units}</span>{' '}
+                          <span className="text-slate-600">Â· Ã—{r.units}</span>{' '}
                           <span className="text-slate-700">({pct}%)</span>
                         </span>
                       </div>
@@ -759,7 +759,7 @@ export const ArenaRankDeck: React.FC<Props> = ({
               <ArrowRight size={14} strokeWidth={2.6} className="transition-transform group-hover:translate-x-0.5" />
             </button>
             <p className="mt-1 text-center font-mono text-[9px] uppercase tracking-wider text-slate-600">
-              Preset Â/ {stakeBaseLabel} TRUST per unit
+              Preset Â· {stakeBaseLabel} TRUST per unit
             </p>
           </div>
         </aside>

--- a/pages/ArenaPlaceholder.tsx
+++ b/pages/ArenaPlaceholder.tsx
@@ -45,7 +45,7 @@ const ArenaPlaceholder: React.FC = () => {
           </p>
           <p className="text-[10px] uppercase tracking-[0.2em] text-slate-600 mb-10 flex items-center justify-center gap-2">
             <Swords size={12} className="text-fuchsia-400/80" />
-            Masked for this build Â/ route preserved
+            Masked for this build Â· route preserved
           </p>
 
           <div className="flex flex-col sm:flex-row gap-3 justify-center">

--- a/pages/Compare.tsx
+++ b/pages/Compare.tsx
@@ -80,7 +80,7 @@ export const RivalryAnalysis: React.FC<{
                         </div>
                         <div className="min-w-0">
                             <h3 className="text-[11px] font-black uppercase tracking-[0.2em] text-white font-display">Battle summary</h3>
-                            <p className="text-[10px] text-slate-500 mt-0.5 uppercase tracking-wider">Plain-language Â/ optional AI</p>
+                            <p className="text-[10px] text-slate-500 mt-0.5 uppercase tracking-wider">Plain-language Â· optional AI</p>
                         </div>
                     </div>
 

--- a/pages/CreateSignal.tsx
+++ b/pages/CreateSignal.tsx
@@ -584,7 +584,7 @@ const CreateSignal: React.FC = () => {
     <div className="mt-6 flex w-full items-center justify-center gap-3 border-t border-white/[0.06] pt-5 font-mono text-[9px] uppercase tracking-[0.2em] text-slate-600">
       <span className="font-black text-slate-500">S05_CREATE</span>
       <span className="text-intuition-primary/35" aria-hidden>
-        Â/
+        Â·
       </span>
       <span className="font-black text-intuition-success text-glow-success">Sync active</span>
     </div>
@@ -1067,7 +1067,7 @@ const CreateSignal: React.FC = () => {
                 <div className="flex flex-col items-center justify-center gap-3 rounded-[1.35rem] border border-dashed border-white/15 bg-[#04060c]/90 p-8 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] backdrop-blur-sm">
                   <Camera size={28} className="text-slate-500" />
                   <span className="text-[9px] font-black uppercase tracking-widest text-slate-500">Upload image</span>
-                  <span className="text-[8px] text-slate-600">PNG / JPG Â/ max 5MB</span>
+                  <span className="text-[8px] text-slate-600">PNG / JPG Â· max 5MB</span>
                   <label className="mt-1 cursor-pointer rounded-full border border-intuition-primary/40 bg-intuition-primary/10 px-5 py-2.5 text-[10px] font-black uppercase text-intuition-primary transition-all hover:bg-intuition-primary/20">
                     <input type="file" accept="image/png,image/jpeg,image/jpg" onChange={handleImageFileChange} className="sr-only" />
                     Choose file

--- a/pages/Documentation.tsx
+++ b/pages/Documentation.tsx
@@ -523,7 +523,7 @@ const Documentation: React.FC = () => {
           >
             <div className="mb-10 md:mb-14 max-w-[52rem]">
               <p className="text-[11px] font-mono text-slate-500 uppercase tracking-[0.2em] mb-3">
-                {APP_VERSION_DISPLAY} �/ {NETWORK_NAME} �/ chain {CHAIN_ID}
+                {APP_VERSION_DISPLAY} · {NETWORK_NAME} · chain {CHAIN_ID}
               </p>
               <p className="text-base sm:text-lg text-slate-400 leading-relaxed">
                 A full-stack guide to IntuRank {APP_VERSION_DISPLAY}: the trust graph, how markets price conviction with
@@ -726,7 +726,7 @@ const Documentation: React.FC = () => {
                 <ProseLink href={EXPLORER_URL}>explorer</ProseLink>.
               </p>
               <p className="text-xs font-mono text-slate-500 bg-black/40 border border-white/5 rounded-lg px-3 py-2">
-                App release {APP_VERSION} �/ curve IDs {LINEAR_CURVE_ID} (linear) and {OFFSET_PROGRESSIVE_CURVE_ID}{' '}
+                App release {APP_VERSION} · curve IDs {LINEAR_CURVE_ID} (linear) and {OFFSET_PROGRESSIVE_CURVE_ID}{' '}
                 (offset progressive) match protocol constants in this build
               </p>
 
@@ -888,7 +888,7 @@ const Documentation: React.FC = () => {
 
               <div className="not-prose space-y-4 mt-4 text-[13px]">
                 <div className="rounded-xl border border-white/10 bg-[#080a10] p-4">
-                  <p className="text-xs font-semibold text-intuition-primary mb-2">French �/ create atom</p>
+                  <p className="text-xs font-semibold text-intuition-primary mb-2">French · create atom</p>
                   <pre className="text-slate-300 font-mono whitespace-pre-wrap break-words [overflow-wrap:anywhere] leading-relaxed">
                     {`Crée un atome nommé « Réseau Nova » avec un dépôt de 0,5 TRUST. Description : communauté open-source autour de la réputation on-chain.`}
                   </pre>
@@ -899,7 +899,7 @@ const Documentation: React.FC = () => {
                   </p>
                 </div>
                 <div className="rounded-xl border border-white/10 bg-[#080a10] p-4">
-                  <p className="text-xs font-semibold text-intuition-primary mb-2">Spanish �/ triple / claim</p>
+                  <p className="text-xs font-semibold text-intuition-primary mb-2">Spanish · triple / claim</p>
                   <pre className="text-slate-300 font-mono whitespace-pre-wrap break-words [overflow-wrap:anywhere] leading-relaxed">
                     {`Quiero registrar la afirmación: el sujeto es "DAO Alpha", el predicado es "colabora_con", el objeto es "Estudio Beta". Depósito de bóveda 0.5 TRUST.`}
                   </pre>
@@ -913,7 +913,7 @@ const Documentation: React.FC = () => {
                   </p>
                 </div>
                 <div className="rounded-xl border border-white/10 bg-[#080a10] p-4">
-                  <p className="text-xs font-semibold text-intuition-primary mb-2">German �/ question only (no tx)</p>
+                  <p className="text-xs font-semibold text-intuition-primary mb-2">German · question only (no tx)</p>
                   <pre className="text-slate-300 font-mono whitespace-pre-wrap break-words [overflow-wrap:anywhere] leading-relaxed">
                     {`Was ist der Unterschied zwischen einem Atom und einem Triple im Intuition-Protokoll? Antworte kurz auf Deutsch.`}
                   </pre>
@@ -923,7 +923,7 @@ const Documentation: React.FC = () => {
                   </p>
                 </div>
                 <div className="rounded-xl border border-white/10 bg-[#080a10] p-4">
-                  <p className="text-xs font-semibold text-intuition-primary mb-2">Japanese �/ explain + create</p>
+                  <p className="text-xs font-semibold text-intuition-primary mb-2">Japanese · explain + create</p>
                   <pre className="text-slate-300 font-mono whitespace-pre-wrap break-words [overflow-wrap:anywhere] leading-relaxed">
                     {`TRUSTのデポジット最小値を日本語で一言で教えて。そのあと「オープン研究ラボ」という名前の原子を0.5 TRUSTで作るための手順を出して。`}
                   </pre>
@@ -934,7 +934,7 @@ const Documentation: React.FC = () => {
                   </p>
                 </div>
                 <div className="rounded-xl border border-white/10 bg-[#080a10] p-4">
-                  <p className="text-xs font-semibold text-intuition-primary mb-2">English �/ explicit triple (labels)</p>
+                  <p className="text-xs font-semibold text-intuition-primary mb-2">English · explicit triple (labels)</p>
                   <pre className="text-slate-300 font-mono whitespace-pre-wrap break-words [overflow-wrap:anywhere] leading-relaxed">
                     {`Create a triple: subject "Alice", predicate "endorses", object "Bob", depositTrust 0.5, chain 1155. One-line description: social trust edge.`}
                   </pre>
@@ -1166,7 +1166,7 @@ const Documentation: React.FC = () => {
                       </td>
                     </tr>
                     <tr>
-                      <td className="px-4 py-3 text-slate-200">Arena �/ stance batch (vault deposit)</td>
+                      <td className="px-4 py-3 text-slate-200">Arena · stance batch (vault deposit)</td>
                       <td className="px-4 py-3 font-mono tabular-nums text-amber-200/95">+{PROTOCOL_XP_ADD_TO_LIST}</td>
                       <td className="px-4 py-3 text-slate-500 text-[13px] leading-snug">
                         Same <strong className="text-slate-400 font-semibold">add-to-list</strong> category when you submit ranked picks: deposit-scaled, then the gross is multiplied by{' '}
@@ -1174,7 +1174,7 @@ const Documentation: React.FC = () => {
                       </td>
                     </tr>
                     <tr>
-                      <td className="px-4 py-3 text-slate-200">Signal �/ Vouch batch (FeeProxy createTriples)</td>
+                      <td className="px-4 py-3 text-slate-200">Signal · Vouch batch (FeeProxy createTriples)</td>
                       <td className="px-4 py-3 font-mono tabular-nums text-amber-200/95">+{PROTOCOL_XP_CREATE_CLAIM}</td>
                       <td className="px-4 py-3 text-slate-500 text-[13px] leading-snug">
                         Activity XP — treated like <strong className="text-slate-400 font-semibold">created a claim</strong>. One transaction can mint several “vouches for” triples; the deposit basis is the{' '}
@@ -1794,7 +1794,7 @@ const Documentation: React.FC = () => {
             </div>
 
             <footer className="mt-12 pt-8 border-t border-white/5 flex flex-col sm:flex-row items-center justify-between gap-3 text-xs text-slate-600">
-              <span>© 2026 IntuRank �/ {APP_VERSION_DISPLAY}</span>
+              <span>© 2026 IntuRank · {APP_VERSION_DISPLAY}</span>
               <span className="font-mono text-[10px] uppercase tracking-wider">{NETWORK_NAME}</span>
             </footer>
           </div>

--- a/pages/KPIDashboard.tsx
+++ b/pages/KPIDashboard.tsx
@@ -161,7 +161,7 @@ const KPIDashboard: React.FC = () => {
                 <div className="space-y-2 min-w-0">
                     <div className="flex items-center gap-2 text-slate-500">
                         <ShieldCheck size={16} className="shrink-0 text-intuition-secondary/90" aria-hidden />
-                        <p className={PAGE_HERO_EYEBROW}>Intuition Mainnet Â/ operator metrics</p>
+                        <p className={PAGE_HERO_EYEBROW}>Intuition Mainnet Â· operator metrics</p>
                     </div>
                     <h1 className={`${PAGE_HERO_TITLE} mobile-break`}>System health</h1>
                 </div>
@@ -289,7 +289,7 @@ const KPIDashboard: React.FC = () => {
                                     <Terminal size={14} className="shrink-0 text-cyan-400" aria-hidden />
                                     <div>
                                         <h4 className="text-sm font-bold tracking-tight text-cyan-200">Fee proxy activity</h4>
-                                        <p className="mt-1 text-[10px] font-medium text-slate-400">Indexed deposits &amp; redemptions Â/ auto ~12s</p>
+                                        <p className="mt-1 text-[10px] font-medium text-slate-400">Indexed deposits &amp; redemptions Â· auto ~12s</p>
                                     </div>
                                 </div>
                                 <div className="ml-auto flex shrink-0 flex-wrap items-center justify-end gap-2">
@@ -459,12 +459,12 @@ const KPIDashboard: React.FC = () => {
                          </div>
                          <div>
                              <div className="text-xs font-semibold font-display text-white mb-1">IntuRank health report</div>
-                             <div className="text-[10px] font-medium text-slate-500">On-chain metrics Â/ subgraph + fee proxy</div>
+                             <div className="text-[10px] font-medium text-slate-500">On-chain metrics Â· subgraph + fee proxy</div>
                          </div>
                     </div>
                     <div className="text-left sm:text-right flex flex-col items-start sm:items-end gap-1">
                          <div className="text-xs font-medium text-slate-300">{new Date().toLocaleDateString(undefined, { dateStyle: 'medium' })}</div>
-                         <div className="text-[10px] font-medium text-slate-600">Exported view Â/ not financial advice</div>
+                         <div className="text-[10px] font-medium text-slate-600">Exported view Â· not financial advice</div>
                     </div>
                 </div>
             </div>

--- a/pages/Markets.tsx
+++ b/pages/Markets.tsx
@@ -463,7 +463,7 @@ const Markets: React.FC = () => {
       <div className="flex flex-col lg:flex-row lg:items-start justify-between mb-6 md:mb-12 gap-4 md:gap-8 border-b border-white/10 pb-6 md:pb-10 relative z-10 max-md:pb-5">
         <div className="relative z-10 min-w-0 max-w-2xl shrink-0 space-y-2 md:space-y-3">
           <p className="text-xs md:text-sm text-slate-500 font-sans">
-            Reputation Â/ {APP_VERSION_DISPLAY}
+            Reputation Â· {APP_VERSION_DISPLAY}
           </p>
           <h1 className={`${PAGE_HERO_TITLE} max-md:text-2xl max-md:leading-tight`}>Markets</h1>
           <p className="text-sm md:text-[15px] text-slate-400 leading-relaxed font-sans max-md:line-clamp-3">
@@ -852,7 +852,7 @@ const Markets: React.FC = () => {
                 const obj = claim.object?.label || 'â€”';
                 const predRaw = String(claim.predicate || 'link').replace(/_/g, ' ');
                 const pred = predRaw.charAt(0).toUpperCase() + predRaw.slice(1).toLowerCase();
-                const titleHint = `${subj} Â/ ${pred} Â/ ${obj}`;
+                const titleHint = `${subj} Â· ${pred} Â· ${obj}`;
                 return (
                   <div
                     key={claim.id}
@@ -888,7 +888,7 @@ const Markets: React.FC = () => {
                               <Users size={12} /> Support
                             </div>
                             <p className="text-xs font-bold text-[#3498DB] tabular-nums">
-                              {formatLargeNumber(claim.holders)} Â/ {formatMarketValue(claim.value)}
+                              {formatLargeNumber(claim.holders)} Â· {formatMarketValue(claim.value)}
                             </p>
                           </div>
                           <div className="rounded-xl bg-[#F39C12]/10 border border-[#F39C12]/25 px-3 py-2">
@@ -896,7 +896,7 @@ const Markets: React.FC = () => {
                               <Users size={12} /> Oppose
                             </div>
                             <p className="text-xs font-bold text-[#F39C12] tabular-nums">
-                              {formatLargeNumber(claim.opposeHolders || 0)} Â/ {formatMarketValue(claim.opposeValue || 0)}
+                              {formatLargeNumber(claim.opposeHolders || 0)} Â· {formatMarketValue(claim.opposeValue || 0)}
                             </p>
                           </div>
                         </div>

--- a/pages/MobileHome.tsx
+++ b/pages/MobileHome.tsx
@@ -192,18 +192,18 @@ const MobileHome: React.FC = () => {
               </p>
               <div
                 className="mt-1 flex items-baseline gap-2"
-                title={`Arena ${arenaSelf.xp.toLocaleString()} Â/ Activity ${activityXp.toLocaleString()} (this browser)`}
+                title={`Arena ${arenaSelf.xp.toLocaleString()} Â· Activity ${activityXp.toLocaleString()} (this browser)`}
               >
                 <span className="text-3xl font-display font-black text-white leading-none tracking-tight">
                   {compact(arenaSelf.xp + activityXp)}
                 </span>
                 <span className="text-[11px] font-mono text-slate-500">
-                  Â/ {compact(arenaSelf.duels)} duels
+                  Â· {compact(arenaSelf.duels)} duels
                 </span>
               </div>
               <p className="mt-1 text-[11px] text-slate-400">
                 {isConnected
-                  ? 'Arena from the graph Â/ activity from trades & creates on this device.'
+                  ? 'Arena from the graph Â· activity from trades & creates on this device.'
                   : 'Connect to start earning XP.'}
               </p>
             </div>

--- a/pages/Portfolio.tsx
+++ b/pages/Portfolio.tsx
@@ -735,13 +735,13 @@ const Portfolio: React.FC = () => {
                   </div>
                   <div className="min-w-0 flex flex-col gap-1">
                     <div className="text-[9px] text-slate-500 uppercase tracking-[0.24em]">
-                      Intuition Network Â/ IntuRank
+                      Intuition Network Â· IntuRank
                     </div>
                     <div className="text-base sm:text-lg font-black text-white uppercase tracking-tight leading-tight truncate" title={sharePosition.atom?.label}>
                       {sharePosition.atom?.label}
                     </div>
                     <div className="text-[10px] text-slate-500 font-mono truncate">
-                      UID: {sharePosition.id.slice(0, 12)}â€¦ Â/ Curve: {getCurveLabel(sharePosition.curveId ?? 1)}
+                      UID: {sharePosition.id.slice(0, 12)}â€¦ Â· Curve: {getCurveLabel(sharePosition.curveId ?? 1)}
                     </div>
                   </div>
                 </div>
@@ -912,7 +912,7 @@ const Portfolio: React.FC = () => {
                             >
                               {pos.atom?.label || 'Unknown'}
                             </p>
-                            <p className="mt-0.5 font-mono text-[10px] text-slate-500 truncate">UID Â/ {pos.id.slice(0, 10)}â€¦</p>
+                            <p className="mt-0.5 font-mono text-[10px] text-slate-500 truncate">UID Â· {pos.id.slice(0, 10)}â€¦</p>
                           </div>
                           <div className={`shrink-0 text-right text-sm font-bold tabular-nums ${pos.pnl >= 0 ? 'text-intuition-success' : 'text-intuition-danger'}`}>
                             {pos.pnl >= 0 ? '+' : ''}
@@ -933,7 +933,7 @@ const Portfolio: React.FC = () => {
                           </div>
                         </div>
                         <p className="mt-2 text-[10px] text-slate-500 truncate" title={getCurveLabel(pos.curveId ?? 1)}>
-                          Curve Â/ {getCurveLabel(pos.curveId ?? 1)}
+                          Curve Â· {getCurveLabel(pos.curveId ?? 1)}
                         </p>
                         <div className="mt-3 flex gap-2">
                           <Link
@@ -1066,7 +1066,7 @@ const Portfolio: React.FC = () => {
             {sortedPositions.length > HOLDINGS_PER_PAGE && (
               <div className="px-4 sm:px-5 md:px-6 xl:px-8 py-4 border-t border-slate-900 flex flex-wrap items-center justify-between gap-4">
                 <div className="text-[10px] sm:text-xs font-mono text-slate-500 uppercase tracking-widest">
-                  Page {holdingsPage} of {totalHoldingsPages} Â/ {sortedPositions.length} total
+                  Page {holdingsPage} of {totalHoldingsPages} Â· {sortedPositions.length} total
                 </div>
                 <div className="flex items-center gap-2">
                   <button

--- a/pages/PublicProfile.tsx
+++ b/pages/PublicProfile.tsx
@@ -716,7 +716,7 @@ const PublicProfile: React.FC = () => {
                 <div className="flex flex-wrap items-center justify-center gap-2 md:justify-start sm:gap-3">
                   {/* {address && <BadgesSection address={address} compact />} */}
                   <span className="rounded-full border border-intuition-primary/40 bg-gradient-to-r from-intuition-primary/25 to-intuition-primary/10 px-3.5 py-2 font-sans text-xs font-semibold text-intuition-primary shadow-[0_0_24px_rgba(255,80,57,0.12)] [text-rendering:geometricPrecision]">
-                    {activeHoldingsCount > 50 ? 'Level Â/ Elite' : activeHoldingsCount > 10 ? 'Level Â/ Pro' : 'Level Â/ Explorer'}
+                    {activeHoldingsCount > 50 ? 'Level Â· Elite' : activeHoldingsCount > 10 ? 'Level Â· Pro' : 'Level Â· Explorer'}
                   </span>
                   <span className="rounded-full border border-white/15 bg-white/[0.06] px-3.5 py-2 font-sans text-xs font-medium text-slate-200 backdrop-blur-sm [text-rendering:geometricPrecision]">
                     {activeHoldingsCount >= 100 ? `${activeHoldingsCount}+` : activeHoldingsCount} open positions
@@ -797,7 +797,7 @@ const PublicProfile: React.FC = () => {
                       >
                         <UserPlus size={16} strokeWidth={2} className="shrink-0" />
                         <span className="text-sm font-semibold tracking-normal antialiased" style={{ fontFamily: 'system-ui, -apple-system, sans-serif' }}>
-                          Follow Â/ Email when they buy
+                          Follow Â· Email when they buy
                         </span>
                       </button>
                     )}
@@ -946,7 +946,7 @@ const PublicProfile: React.FC = () => {
               <div className="mb-2 flex min-w-0 items-center gap-2 sm:mb-3">
                 <Wallet size={14} className="shrink-0 text-intuition-primary" />
                 <span className="min-w-0 truncate font-sans text-[10px] font-semibold text-slate-300 sm:text-xs [text-rendering:geometricPrecision]">
-                  Wallet Â/ TNS / ENS / address
+                  Wallet Â· TNS / ENS / address
                 </span>
               </div>
               <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between sm:gap-4">
@@ -1036,7 +1036,7 @@ const PublicProfile: React.FC = () => {
       )}
       
       {/*
-        5-column row at lg: mix 40% Â/ activity 60%. From sm: two columns so charts sit side-by-side on phones/tablets.
+        5-column row at lg: mix 40% Â· activity 60%. From sm: two columns so charts sit side-by-side on phones/tablets.
       */}
       <div className="mb-12 grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-5 lg:grid-cols-5 lg:gap-6">
           <div className={`${GLASS_SHEET} group flex min-h-[300px] flex-col p-4 sm:min-h-[320px] sm:p-6 lg:col-span-2 lg:min-h-[360px] lg:p-8 motion-hover-lift`}>

--- a/pages/RankedList.tsx
+++ b/pages/RankedList.tsx
@@ -369,7 +369,7 @@ const ARENA_STAKE_TITLES = ARENA_BATCH_MODE
   ? (['Pulse', 'Surge', 'Blitz', 'Nova', 'Forge', 'Singularity'] as const)
   : (['Spark', 'Pulse', 'Surge', 'Blitz', 'Nova', 'Singularity'] as const);
 
-/** Per-card multiplier in Step 2 Â/ Rank (batch deposit = stake preset Ã— units per row). */
+/** Per-card multiplier in Step 2 Â· Rank (batch deposit = stake preset Ã— units per row). */
 const RANK_TRUST_UNITS_MAX = 12;
 
 const NARRATIVE_PRED = /predict|forecast|will\b|should\b|believe|future|outcome|if\s+.+\s+then/i;
@@ -881,13 +881,13 @@ function ArenaLaneCard({
                 <Zap size={12} className="shrink-0 text-intuition-primary/90" aria-hidden />+{xpRoundTotal} XP
               </span>
               <span className="text-slate-600" aria-hidden>
-                Â/
+                Â·
               </span>
               {item.subtitle ? (
                 <>
                   <span className="truncate text-slate-500">{item.subtitle}</span>
                   <span className="text-slate-600" aria-hidden>
-                    Â/
+                    Â·
                   </span>
                 </>
               ) : null}
@@ -1481,7 +1481,7 @@ const RankedList: React.FC = () => {
             source: 'portal' as const,
             listObjectTermId: row.id,
             title: row.label || 'Untitled list',
-            description: `Intuition list Â/ ${
+            description: `Intuition list Â· ${
               typeof row.totalItems === 'number' ? `${row.totalItems} members indexed` : 'live on the graph'
             }`,
             tag: 'Live',
@@ -2412,8 +2412,8 @@ const RankedList: React.FC = () => {
       if (tripleCreateInputs.length > 0) {
         setSubmitProgress(
           tripleCreateInputs.length > 1
-            ? `Confirm in wallet Â/ create ${tripleCreateInputs.length} claims (one transaction)`
-            : 'Confirm in wallet Â/ create claim',
+            ? `Confirm in wallet Â· create ${tripleCreateInputs.length} claims (one transaction)`
+            : 'Confirm in wallet Â· create claim',
         );
         const createHash = await createSemanticTriplesBatch(tripleCreateInputs, address, progressCb);
         for (const x of tripleCreateLegacyRows) {
@@ -2431,8 +2431,8 @@ const RankedList: React.FC = () => {
       if (mergedDepositLegs.length > 0) {
         setSubmitProgress(
           mergedDepositLegs.length > 1
-            ? `Confirm in wallet Â/ ${mergedDepositLegs.length} vault deposits (one transaction)`
-            : 'Confirm in wallet Â/ vault deposit',
+            ? `Confirm in wallet Â· ${mergedDepositLegs.length} vault deposits (one transaction)`
+            : 'Confirm in wallet Â· vault deposit',
         );
         const { hash: depHash } = await depositBatchToVaults(mergedDepositLegs, address, progressCb);
         for (const x of depositXpRows) {
@@ -2509,7 +2509,7 @@ const RankedList: React.FC = () => {
           const side = r.support ? 'YES' : 'NO';
           return `${side} for â€œ${r.item.label}â€ in â€œ${lt}â€`;
         });
-        humanLine = `${who}: ${rowSummaries.join(' Â/ ')}`;
+        humanLine = `${who}: ${rowSummaries.join(' Â· ')}`;
       } catch {
         /* ignore */
       }
@@ -3352,7 +3352,7 @@ const RankedList: React.FC = () => {
                 }}
               >
                 <span aria-hidden className="h-1.5 w-1.5 rounded-full animate-pulse" style={{ background: ARENA_THEME.cyan }} />
-                IntuRank Â/ Climb
+                IntuRank Â· Climb
               </p>
               <h1
                 className="mt-3 text-3xl sm:text-4xl md:text-5xl font-black font-display tracking-tight bg-clip-text text-transparent drop-shadow-[0_0_42px_rgba(255,80,57,0.12)] leading-[1.05]"
@@ -3392,7 +3392,7 @@ const RankedList: React.FC = () => {
                 ) : climbViewMode === 'signal' ? (
                   <>
                     Stake your conviction on triples surfacing across Intuition.{' '}
-                    <span className="text-intuition-primary font-semibold">STAND</span> Â/ or Â/{' '}
+                    <span className="text-intuition-primary font-semibold">STAND</span> Â· or Â·{' '}
                     <span className="text-intuition-secondary font-semibold">OPPOSE</span>.
                   </>
                 ) : listId ? (
@@ -3401,7 +3401,7 @@ const RankedList: React.FC = () => {
                       <span style={{ color: ARENA_THEME.cyanMuted }} className="font-semibold">Yes</span>
                       {' / '}
                       <span style={{ color: ARENA_THEME.roseNo }} className="font-semibold">No</span>
-                      {' Â/ batch when ready.'}
+                      {' Â· batch when ready.'}
                     </>
                   ) : (
                     'Pick now. Wallet only when you stake.'
@@ -3496,7 +3496,7 @@ const RankedList: React.FC = () => {
                         type="button"
                         onClick={() => setClimbViewMode('signal')}
                         aria-pressed={climbViewMode === 'signal'}
-                        title="Stance feed Â/ stake your conviction on circulating triples"
+                        title="Stance feed Â· stake your conviction on circulating triples"
                         whileTap={reduceMotion ? undefined : { scale: 0.96 }}
                         transition={{ type: 'spring', stiffness: 520, damping: 32 }}
                         className={`relative inline-flex flex-1 min-w-[4.75rem] items-center justify-center gap-1.5 rounded-lg px-2.5 sm:px-3 py-2.5 text-[10px] sm:text-[11px] font-black uppercase tracking-[0.14em] transition-all duration-200 ${
@@ -3592,7 +3592,7 @@ const RankedList: React.FC = () => {
                                 <span className="text-slate-600 font-mono uppercase tracking-wider text-[9px] shrink-0">XP</span>
                                 <span
                                   className="text-slate-500 min-w-0 truncate"
-                                  title={`Arena ${arenaXpUi.toLocaleString()} (indexer ${graphArenaXp.toLocaleString()} Â/ this device picks ${arenaPickXp.toLocaleString()}) Â/ Activity ${myProtocolXp.toLocaleString()} Â/ Total`}
+                                  title={`Arena ${arenaXpUi.toLocaleString()} (indexer ${graphArenaXp.toLocaleString()} Â· this device picks ${arenaPickXp.toLocaleString()}) Â· Activity ${myProtocolXp.toLocaleString()} Â· Total`}
                                 >
                                   <AnimatedXpFigure
                                     ready={arenaGraphReady}
@@ -3636,7 +3636,7 @@ const RankedList: React.FC = () => {
                                     playArenaUiClick();
                                     setStakePresetIdx(idx);
                                   }}
-                                  title={`${amt} TRUST per unit Â/ cart line deposit = preset Ã— weight`}
+                                  title={`${amt} TRUST per unit Â· cart line deposit = preset Ã— weight`}
                                   className={`rounded-md px-2 py-0.5 text-[9px] font-bold tabular-nums transition-colors ${
                                     on
                                       ? 'bg-intuition-primary/25 text-intuition-primary shadow-[inset_0_0_0_1px_rgba(34,211,238,0.45)]'
@@ -3649,7 +3649,7 @@ const RankedList: React.FC = () => {
                             })}
                           </div>
                           <span className="text-[9px] text-slate-600 font-mono">
-                            TRUST/unit Â/ batch: preset Ã— weight
+                            TRUST/unit Â· batch: preset Ã— weight
                           </span>
                         </div>
                       </>
@@ -3803,7 +3803,7 @@ const RankedList: React.FC = () => {
                   </div>
                   <div className="min-w-0">
                     <p className="text-[11px] font-mono font-black uppercase tracking-[0.28em] text-intuition-primary/90">
-                      IntuRank Â/ Arena
+                      IntuRank Â· Arena
                     </p>
                     <p className="text-[13px] text-slate-200 leading-snug mt-0.5">
                       Same dark glass and cyan numbers as your IntuRank profile.
@@ -3881,7 +3881,7 @@ const RankedList: React.FC = () => {
                     <Scale size={18} className="text-intuition-primary" strokeWidth={2.35} />
                   </div>
                   <div className="min-w-0">
-                    <p className="text-[10px] font-mono font-black uppercase tracking-[0.28em] text-intuition-primary/90">Arena Â/ Climb</p>
+                    <p className="text-[10px] font-mono font-black uppercase tracking-[0.28em] text-intuition-primary/90">Arena Â· Climb</p>
                     <h2 className="text-lg sm:text-xl font-black text-white tracking-tight mt-0.5">Pick a list</h2>
                     <p className="text-[11px] text-slate-400 mt-0.5">Tap a list card below to start.</p>
                   </div>
@@ -4211,11 +4211,11 @@ const RankedList: React.FC = () => {
                   </h2>
                   {stanceSummary.total > 0 ? (
                     <p className="text-[11px] text-slate-500 shrink-0 tabular-nums sm:text-right">
-                      {stanceSummary.total} indexed Â/{' '}
+                      {stanceSummary.total} indexed Â·{' '}
                       <span className="font-semibold" style={{ color: ARENA_THEME.cyan }}>
                         yes {stanceSummary.yes}
                       </span>
-                      {' Â/ '}
+                      {' Â· '}
                       <span className="font-semibold" style={{ color: ARENA_THEME.red }}>
                         no {stanceSummary.no}
                       </span>
@@ -4600,7 +4600,7 @@ const RankedList: React.FC = () => {
                           </div>
                           <div className="mt-3 text-center w-full min-w-0 px-1">
                             <div className="text-[12px] font-bold text-slate-100 truncate drop-shadow-sm">
-                              {isYou ? <span className="text-intuition-primary">You Â/ </span> : null}
+                              {isYou ? <span className="text-intuition-primary">You Â· </span> : null}
                               {p.label}
                             </div>
                             <div className="mt-2 h-1.5 rounded-full bg-slate-800/90 overflow-hidden ring-1 ring-white/5">
@@ -4697,12 +4697,12 @@ const RankedList: React.FC = () => {
                                     <span className="font-mono tabular-nums font-bold text-white">{p.duels}</span>
                                     <span className="text-slate-400 font-medium">duels</span>
                                   </span>
-                                  <span className="text-slate-600">Â/</span>
+                                  <span className="text-slate-600">Â·</span>
                                   <span className="text-slate-300">
                                     <span className="text-intuition-warning font-mono tabular-nums font-bold">{avgPick}</span>{' '}
                                     <span className="text-slate-500 font-medium">XP/pick</span>
                                   </span>
-                                  <span className="text-slate-600">Â/</span>
+                                  <span className="text-slate-600">Â·</span>
                                   <span className="inline-flex items-center gap-1 text-slate-300">
                                     <Clock size={11} className="text-intuition-primary/80 shrink-0" />
                                     <span className="font-medium text-slate-200">{formatRelativeArenaActive(p.updatedAt)}</span>
@@ -5000,7 +5000,7 @@ const RankedList: React.FC = () => {
             description:
               activeList && 'description' in activeList && activeList.description
                 ? activeList.description
-                : 'Promoted on-chain Â/ live on the graph',
+                : 'Promoted on-chain Â· live on the graph',
             tag: 'Live',
             arenaCategory,
             listGlyph: activeList?.listGlyph ?? 'â—†',

--- a/pages/SendTrust.tsx
+++ b/pages/SendTrust.tsx
@@ -310,7 +310,7 @@ const SendTrust: React.FC = () => {
                   type="text"
                   value={recipientInput}
                   onChange={(e) => setRecipientInput(e.target.value)}
-                  placeholder="0xâ€¦ Â/ alice.trust Â/ name.eth (complete names only)"
+                  placeholder="0xâ€¦ Â· alice.trust Â· name.eth (complete names only)"
                   autoComplete="off"
                   spellCheck={false}
                   className="w-full px-4 py-4 rounded-xl bg-black/55 border border-[#F0C14B]/28 text-white font-mono text-sm placeholder:text-slate-600 focus:border-[#F0C14B]/55 focus:ring-2 focus:ring-[#F0C14B]/15 focus:outline-none transition-all"
@@ -354,7 +354,7 @@ const SendTrust: React.FC = () => {
                 </div>
                 <p className="mt-3 text-xs text-slate-500 font-mono flex items-center gap-1.5 flex-wrap">
                   <Coins size={12} className="text-[#F0C14B]/80 shrink-0" /> Balance: {balanceFormatted} TRUST
-                  <span className="text-[#8B5CF6]/80">Â/ Live</span>
+                  <span className="text-[#8B5CF6]/80">Â· Live</span>
                 </p>
               </div>
 


### PR DESCRIPTION
## What
A stray `0xC2` byte before `/` (`0xC2 0x2F`) corrupted the middle-dot (`·`) separator in **146 places across 31 files**. Nixpacks (Rust) hard-fails reading these (`stream did not contain valid UTF-8`), which blocks the website deploy; esbuild/Docker tolerated it (so the API built fine).

## Fix
Byte-level replace `0xC2 0x2F` → `0xC2 0xB7` (`·`). Display strings/comments only — **no logic change**, tsc error count unchanged (35 pre-existing), repo now 100% valid UTF-8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)