### PR TITLE
fix: live IPFS gateway, CORS-safe ENS RPC, normalize all <img> sources

### DIFF
--- a/components/ActivityRow.tsx
+++ b/components/ActivityRow.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { normalizeWebMediaUrl } from '../services/mediaUrl';
 import { Link } from 'react-router-dom';
 import { User, ExternalLink, Activity as PulseIcon, Box, Zap, AlertCircle, Fingerprint, Network, Database, TrendingUp, TrendingDown, Crown } from 'lucide-react';
 import { formatEther } from 'viem';
@@ -111,7 +112,7 @@ const ActivityRow: React.FC<ActivityRowProps> = ({ event }) => {
                         style={{ borderColor: `${colorHex}66` }}
                     >
                         {event.sender?.image ? (
-                            <img src={event.sender.image} className="w-full h-full object-cover grayscale group-hover:grayscale-0 transition-all duration-500" alt="" />
+                            <img src={normalizeWebMediaUrl(event.sender.image)} className="w-full h-full object-cover grayscale group-hover:grayscale-0 transition-all duration-500" alt="" />
                         ) : (
                             <User size={18} className="text-slate-800" />
                         )}
@@ -165,7 +166,7 @@ const ActivityRow: React.FC<ActivityRowProps> = ({ event }) => {
                 <div className="flex items-center gap-2 bg-white/[0.04] border border-white/[0.08] px-2 py-1.5 rounded-xl hover:border-white/15 transition-all duration-300 group/target cursor-pointer min-w-0 max-w-full">
                     <div className="w-4 h-4 sm:w-[18px] sm:h-[18px] rounded-md bg-black/50 flex items-center justify-center overflow-hidden border border-white/10 shrink-0 group-hover:scale-105 transition-transform">
                         {event.target?.image ? (
-                            <img src={event.target.image} className="w-full h-full object-cover" alt="" />
+                            <img src={normalizeWebMediaUrl(event.target.image)} className="w-full h-full object-cover" alt="" />
                         ) : (
                             <Box size={10} className="text-slate-700" />
                         )}

--- a/components/AddToListModal.tsx
+++ b/components/AddToListModal.tsx
@@ -3,6 +3,7 @@
  * Mirrors Intuition Portal "Add to List" / "Locked In" flow.
  */
 import React, { useState, useCallback } from 'react';
+import { normalizeWebMediaUrl } from '../services/mediaUrl';
 import { X, Plus, Loader2, Lock } from 'lucide-react';
 import { useAccount } from 'wagmi';
 import { useConnectModal } from '@rainbow-me/rainbowkit';
@@ -213,7 +214,7 @@ const AddToListModal: React.FC<AddToListModalProps> = ({ isOpen, listId, listLab
                       className="w-full flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-white/5 text-left disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       <div className="w-8 h-8 rounded-lg bg-slate-900 border border-slate-700 overflow-hidden flex items-center justify-center shrink-0">
-                        {a.image ? <img src={a.image} alt="" className="w-full h-full object-cover" /> : <span className="text-[10px] font-bold text-intuition-primary">{a.label?.slice(0, 2)}</span>}
+                        {a.image ? <img src={normalizeWebMediaUrl(a.image)} alt="" className="w-full h-full object-cover" /> : <span className="text-[10px] font-bold text-intuition-primary">{a.label?.slice(0, 2)}</span>}
                       </div>
                       <span className="text-sm font-mono text-white truncate flex-1">{a.label || 'Unnamed'}</span>
                       <Plus size={14} className="text-intuition-primary shrink-0" />
@@ -227,7 +228,7 @@ const AddToListModal: React.FC<AddToListModalProps> = ({ isOpen, listId, listLab
                   {selectedAtoms.map((a) => (
                     <div key={a.id} className="flex items-center gap-3 px-3 py-2 rounded-lg bg-black/40 border border-slate-700">
                       <div className="w-8 h-8 rounded-lg bg-slate-900 overflow-hidden flex items-center justify-center shrink-0">
-                        {a.image ? <img src={a.image} alt="" className="w-full h-full object-cover" /> : <span className="text-[10px] font-bold text-intuition-primary">{a.label?.slice(0, 2)}</span>}
+                        {a.image ? <img src={normalizeWebMediaUrl(a.image)} alt="" className="w-full h-full object-cover" /> : <span className="text-[10px] font-bold text-intuition-primary">{a.label?.slice(0, 2)}</span>}
                       </div>
                       <span className="text-sm font-mono text-white truncate flex-1">{a.label || 'Unnamed'}</span>
                       <button onClick={() => removeAtom(a.id)} className="p-1 text-slate-500 hover:text-red-400 transition-colors">

--- a/components/ArenaLeaderboardGlance.tsx
+++ b/components/ArenaLeaderboardGlance.tsx
@@ -5,6 +5,7 @@
  * the ranking flow. Links out to the full leaderboard at /stats?tab=rankers.
  */
 import React, { useMemo } from 'react';
+import { normalizeWebMediaUrl } from '../services/mediaUrl';
 import { Link } from 'react-router-dom';
 import { motion, useReducedMotion } from 'framer-motion';
 import { Trophy, Crown, ArrowUpRight, Award, Sparkles, Loader2 } from 'lucide-react';
@@ -229,7 +230,7 @@ const ArenaLeaderboardGlance: React.FC<Props> = ({
                     >
                       <div className={`${isFirst ? 'w-10 h-10' : 'w-8 h-8'} rounded-full overflow-hidden ${isLight ? 'bg-slate-100' : 'bg-[#040810]'}`}>
                         {p.image ? (
-                          <img src={p.image} alt="" className="w-full h-full object-cover" />
+                          <img src={normalizeWebMediaUrl(p.image)} alt="" className="w-full h-full object-cover" />
                         ) : (
                           <div
                             className={`w-full h-full flex items-center justify-center text-xs font-black ${isLight ? 'text-intuition-primary' : 'text-intuition-primary/90'}`}

--- a/components/ArenaListCard.tsx
+++ b/components/ArenaListCard.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { normalizeWebMediaUrl } from '../services/mediaUrl';
 import { motion } from 'framer-motion';
 import { ArrowRight, ChevronRight, Star } from 'lucide-react';
 import { playArenaUiHover } from '../services/audio';
@@ -187,7 +188,7 @@ const ArenaListCard: React.FC<Props> = ({
                 style={{ borderColor: '#0c0e12', background: 'rgba(30,32,38,0.95)', zIndex: 5 - i }}
               >
                 {it.image ? (
-                  <img src={it.image} className="w-full h-full object-cover" alt="" />
+                  <img src={normalizeWebMediaUrl(it.image)} className="w-full h-full object-cover" alt="" />
                 ) : (
                   (it.label || '?').charAt(0).toUpperCase()
                 )}

--- a/components/ArenaMyRankingsPanel.tsx
+++ b/components/ArenaMyRankingsPanel.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { normalizeWebMediaUrl } from '../services/mediaUrl';
 import { Link } from 'react-router-dom';
 import { Activity, ChevronDown, ChevronRight, Layers, Loader2, RefreshCw } from 'lucide-react';
 import { playArenaUiClick, playArenaUiHover } from '../services/audio';
@@ -355,7 +356,7 @@ function ArenaListOnchainCard({
                     <div className="flex items-center gap-2 min-w-0">
                       <div className="w-9 h-9 rounded-xl overflow-hidden shrink-0 border border-slate-700/90 bg-black/70">
                         {r.subjectImage ? (
-                          <img src={r.subjectImage} alt="" className="w-full h-full object-cover" />
+                          <img src={normalizeWebMediaUrl(r.subjectImage)} alt="" className="w-full h-full object-cover" />
                         ) : (
                           <div className="w-full h-full flex items-center justify-center text-[11px] font-black text-slate-600">
                             {(r.subjectLabel || '?').charAt(0).toUpperCase()}

--- a/components/ClaimCard.tsx
+++ b/components/ClaimCard.tsx
@@ -1,5 +1,6 @@
 
 import React, { useState } from 'react';
+import { normalizeWebMediaUrl } from '../services/mediaUrl';
 import { Link } from 'react-router-dom';
 import { User, Shield, CheckCircle, AlertTriangle, MessageSquare, Activity, Tag, Binary, Fingerprint, ChevronsRight, Share2, ChevronDown, UserCircle, Globe, Hash, BadgeCheck } from 'lucide-react';
 import { Claim } from '../types';
@@ -62,7 +63,7 @@ const ClaimCard: React.FC<{ claim: Claim }> = ({ claim }) => {
         <div className="flex items-center gap-3 w-full md:w-[30%] shrink-0">
           <div className="w-10 h-10 bg-black border border-white/10 flex items-center justify-center overflow-hidden shrink-0 clip-path-slant group-hover:border-intuition-primary/40 transition-colors relative">
               {claim.subject.image ? (
-                  <img src={claim.subject.image} className="w-full h-full object-cover grayscale group-hover:grayscale-0 transition-all duration-500" alt="" />
+                  <img src={normalizeWebMediaUrl(claim.subject.image)} className="w-full h-full object-cover grayscale group-hover:grayscale-0 transition-all duration-500" alt="" />
               ) : (
                   <User size={16} className="text-slate-600" />
               )}
@@ -114,7 +115,7 @@ const ClaimCard: React.FC<{ claim: Claim }> = ({ claim }) => {
           </div>
           <div className="w-10 h-10 bg-black border border-white/10 flex items-center justify-center overflow-hidden shrink-0 clip-path-slant group-hover:border-intuition-primary/40 transition-colors relative">
                 {claim.object.image ? (
-                    <img src={claim.object.image} className="w-full h-full object-cover grayscale group-hover:grayscale-0 transition-all duration-500" alt="" />
+                    <img src={normalizeWebMediaUrl(claim.object.image)} className="w-full h-full object-cover grayscale group-hover:grayscale-0 transition-all duration-500" alt="" />
                 ) : (
                     <Shield size={16} className="text-slate-700" />
                 )}
@@ -152,7 +153,7 @@ const ClaimCard: React.FC<{ claim: Claim }> = ({ claim }) => {
                                 className="flex items-center gap-2 px-3 py-1 bg-intuition-primary/10 border border-intuition-primary/20 hover:border-intuition-primary/60 transition-all clip-path-slant group/creator"
                             >
                                 <div className="w-4 h-4 bg-slate-900 rounded-full border border-white/10 overflow-hidden shrink-0">
-                                    <img src={claim.creator.image || DEFAULT_PROFILE_AVATAR_URL} className="w-full h-full object-cover" alt="" />
+                                    <img src={normalizeWebMediaUrl(claim.creator.image || DEFAULT_PROFILE_AVATAR_URL)} className="w-full h-full object-cover" alt="" />
                                 </div>
                                 <span className="text-[9px] font-black text-intuition-primary group-hover/creator:text-white transition-colors uppercase tracking-widest">
                                     {claim.creator.label || claim.creator.id.slice(0, 14) + '...'}

--- a/components/CreateModal.tsx
+++ b/components/CreateModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { normalizeWebMediaUrl } from '../services/mediaUrl';
 import { X, User, Database, Network, Info, Loader2, Zap, ArrowRight, ShieldCheck, Cpu, Camera, Search, ChevronRight, HelpCircle, UserPlus, CheckCircle2, Globe, Fingerprint, Trash2, Plus, Terminal as TerminalIcon, ExternalLink, RefreshCw, AlertTriangle, Coins, Sparkles } from 'lucide-react';
 import { playClick, playHover } from '../services/audio';
 import { getConnectedAccount, createIdentityAtom, createSemanticTriple, parseProtocolError, getWalletBalance, publicClient, getAtomCreationCost, estimateAtomGas, getMinClaimDeposit, getTotalTripleCreationCost, getProxyApprovalStatus, grantProxyApproval, markProxyApproved, calculateTripleId } from '../services/web3';
@@ -450,7 +451,7 @@ const CreateModal: React.FC<CreateModalProps> = ({ isOpen, onClose }) => {
                               className={`w-full flex items-center gap-4 p-4 rounded-2xl border transition-all text-left ${selectedInSearch?.id === a.id ? 'bg-intuition-primary/10 border-intuition-primary shadow-[0_0_20px_rgba(255,80,57,0.1)]' : 'bg-white/5 border-white/5 hover:border-white/20 hover:bg-white/[0.08]'}`}
                           >
                               <div className="w-12 h-12 bg-black border border-white/10 rounded-xl overflow-hidden shrink-0">
-                                {a.image ? <img src={a.image} className="w-full h-full object-cover" /> : <div className="w-full h-full flex items-center justify-center text-slate-700 bg-slate-900">{target === 'predicate' ? <Zap size={20}/> : <User size={20}/>}</div>}
+                                {a.image ? <img src={normalizeWebMediaUrl(a.image)} className="w-full h-full object-cover" /> : <div className="w-full h-full flex items-center justify-center text-slate-700 bg-slate-900">{target === 'predicate' ? <Zap size={20}/> : <User size={20}/>}</div>}
                               </div>
                               <div className="flex-1 min-w-0">
                                 <div className="text-sm font-bold text-white truncate">{a.label}</div>
@@ -498,7 +499,7 @@ const CreateModal: React.FC<CreateModalProps> = ({ isOpen, onClose }) => {
                       {tripleForm[key] ? (
                         <>
                           <div className="w-12 h-12 bg-black border border-white/10 rounded-xl overflow-hidden shrink-0">
-                            {tripleForm[key]?.image ? <img src={tripleForm[key]?.image} className="w-full h-full object-cover" /> : <div className="w-full h-full flex items-center justify-center text-slate-700 bg-slate-900">{key === 'predicate' ? <Zap size={20}/> : <User size={20}/>}</div>}
+                            {tripleForm[key]?.image ? <img src={normalizeWebMediaUrl(tripleForm[key]?.image)} className="w-full h-full object-cover" /> : <div className="w-full h-full flex items-center justify-center text-slate-700 bg-slate-900">{key === 'predicate' ? <Zap size={20}/> : <User size={20}/>}</div>}
                           </div>
                           <div className="text-left min-w-0">
                             <div className="text-sm font-bold text-white truncate">{tripleForm[key]?.label}</div>
@@ -543,7 +544,7 @@ const CreateModal: React.FC<CreateModalProps> = ({ isOpen, onClose }) => {
                      <div className="space-y-3">
                         <label className="text-[10px] font-bold text-slate-500 uppercase tracking-widest px-1">Image</label>
                         <div onClick={() => fileInputRef.current?.click()} className="aspect-square bg-black border-2 border-dashed border-white/10 rounded-[32px] flex flex-col items-center justify-center gap-4 cursor-pointer hover:border-intuition-primary/40 hover:bg-white/5 transition-all group overflow-hidden shadow-2xl">
-                           {identityForm.image ? <img src={identityForm.image} className="w-full h-full object-cover" /> : <><div className="p-4 bg-white/5 rounded-2xl group-hover:scale-110 transition-transform"><Camera size={32} className="text-slate-600" /></div><div className="text-center"><div className="text-[10px] font-black text-white uppercase tracking-widest">Upload</div></div></>}
+                           {identityForm.image ? <img src={normalizeWebMediaUrl(identityForm.image)} className="w-full h-full object-cover" /> : <><div className="p-4 bg-white/5 rounded-2xl group-hover:scale-110 transition-transform"><Camera size={32} className="text-slate-600" /></div><div className="text-center"><div className="text-[10px] font-black text-white uppercase tracking-widest">Upload</div></div></>}
                            <input type="file" ref={fileInputRef} onChange={handleImageUpload} className="hidden" accept="image/*" />
                         </div>
                      </div>

--- a/components/IntuRankRankersLeaderboard.tsx
+++ b/components/IntuRankRankersLeaderboard.tsx
@@ -3,6 +3,7 @@
  * Rounded glass UI, cyan/magenta/gold gradients (IntuRank brand).
  */
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { normalizeWebMediaUrl } from '../services/mediaUrl';
 import { Link } from 'react-router-dom';
 import { Trophy, RefreshCw, Loader2, Sparkles, Zap, HelpCircle, Gift } from 'lucide-react';
 import { useAccount } from 'wagmi';
@@ -384,7 +385,7 @@ export const IntuRankRankersLeaderboard: React.FC = () => {
                                   }}
                                 >
                                   {p.image ? (
-                                    <img src={p.image} alt="" className="h-full w-full object-cover" />
+                                    <img src={normalizeWebMediaUrl(p.image)} alt="" className="h-full w-full object-cover" />
                                   ) : (
                                     <div
                                       className="flex h-full w-full items-center justify-center text-[15px] font-black text-white"

--- a/components/ProfileShareCard.tsx
+++ b/components/ProfileShareCard.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useState } from 'react';
+import { normalizeWebMediaUrl } from '../services/mediaUrl';
 import { PieChart, Pie, Cell, ResponsiveContainer } from 'recharts';
 import { Download, Twitter, Loader2, Copy } from 'lucide-react';
 import html2canvas from 'html2canvas';
@@ -145,7 +146,7 @@ export default function ProfileShareCard({
                 className="w-14 h-14 shrink-0 bg-black border-2 flex items-center justify-center rounded-[1rem] overflow-hidden shadow-2xl"
                 style={{ borderColor: `${THEME}88`, boxShadow: `0 0 20px ${THEME}44` }}
               >
-                <img src={avatarSrc} alt="" className="w-full h-full object-cover" />
+                <img src={normalizeWebMediaUrl(avatarSrc)} alt="" className="w-full h-full object-cover" />
               </div>
               <div className="min-w-0 pt-0.5">
                 <p className="text-white font-bold font-display text-lg sm:text-xl leading-snug tracking-tight break-words">

--- a/components/ShareCard.tsx
+++ b/components/ShareCard.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState } from 'react';
+import { normalizeWebMediaUrl } from '../services/mediaUrl';
 import { Download, Share2, Award, Copy, Twitter, Loader2, CheckCircle, Activity, Zap, Cpu, User } from 'lucide-react';
 import html2canvas from 'html2canvas';
 import { toast } from './Toast';
@@ -95,7 +96,7 @@ const ShareCard: React.FC<ShareCardProps> = ({
                       style={{ borderColor: `${themeColor}88`, boxShadow: `0 0 20px ${themeColor}44` }}
                     >
                         {assetImage ? (
-                          <img src={assetImage} className="w-full h-full object-cover" crossOrigin="anonymous" alt="" />
+                          <img src={normalizeWebMediaUrl(assetImage)} className="w-full h-full object-cover" crossOrigin="anonymous" alt="" />
                         ) : (
                           <Logo className="w-10 h-10" style={{ filter: `drop-shadow(0 0 5px ${themeColor})` }} />
                         )}

--- a/components/SignalFeed.tsx
+++ b/components/SignalFeed.tsx
@@ -2,6 +2,7 @@
  * Signal — Pulse (stance queue + markets) · Vouch (on-chain name claims).
  */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { normalizeWebMediaUrl } from '../services/mediaUrl';
 import { Link } from 'react-router-dom';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import {
@@ -1141,7 +1142,7 @@ const PulseYoursSearchModal: React.FC<{
                 >
                   <div className="h-9 w-9 rounded-full overflow-hidden ring-1 ring-white/12 bg-zinc-900 shrink-0">
                     {r.image ? (
-                      <img src={r.image} alt="" className="h-full w-full object-cover" />
+                      <img src={normalizeWebMediaUrl(r.image)} alt="" className="h-full w-full object-cover" />
                     ) : (
                       <div className="h-full w-full flex items-center justify-center text-[11px] font-black text-cyan-200">
                         {r.label.slice(0, 1).toUpperCase()}
@@ -1416,7 +1417,7 @@ const PulseLane: React.FC<{
               >
                 <div className="shrink-0 h-12 w-12 rounded-full overflow-hidden ring-1 ring-white/15 bg-slate-900">
                   {it.subjectImage ? (
-                    <img src={it.subjectImage} alt="" className="h-full w-full object-cover" loading="lazy" />
+                    <img src={normalizeWebMediaUrl(it.subjectImage)} alt="" className="h-full w-full object-cover" loading="lazy" />
                   ) : (
                     <div className="h-full w-full flex items-center justify-center text-[13px] font-black text-cyan-100">
                       {it.subjectLabel.slice(0, 1).toUpperCase()}
@@ -2160,7 +2161,7 @@ const PulseAtomTagCard: React.FC<{
           aria-hidden
         >
           {card.subjectImage ? (
-            <img src={card.subjectImage} alt="" className="w-full h-full object-cover" loading="lazy" />
+            <img src={normalizeWebMediaUrl(card.subjectImage)} alt="" className="w-full h-full object-cover" loading="lazy" />
           ) : (
             <User size={18} className="text-zinc-500" />
           )}
@@ -2354,7 +2355,7 @@ const VouchLane: React.FC<{
             >
               <div className="shrink-0 h-11 w-11 rounded-full overflow-hidden ring-1 ring-white/15 bg-slate-900">
                 {i.image ? (
-                  <img src={i.image} alt="" className="h-full w-full object-cover" loading="lazy" />
+                  <img src={normalizeWebMediaUrl(i.image)} alt="" className="h-full w-full object-cover" loading="lazy" />
                 ) : (
                   <div
                     className={`h-full w-full flex items-center justify-center text-[12px] font-black ${

--- a/components/arenaFlow/ArenaContestHub.tsx
+++ b/components/arenaFlow/ArenaContestHub.tsx
@@ -1,4 +1,5 @@
 import React, { memo, useEffect, useState } from 'react';
+import { normalizeWebMediaUrl } from '../../services/mediaUrl';
 import { Link } from 'react-router-dom';
 import { Dices, Plus, Play, Sparkles, Flame, ArrowUpRight, ChevronLeft, ChevronRight } from 'lucide-react';
 import { Reveal } from '../Reveal';
@@ -266,7 +267,7 @@ const PaginatedContestLane = memo(function PaginatedContestLane({
                             className="flex h-6 w-6 items-center justify-center overflow-hidden rounded-md border border-[#0a0d15] bg-slate-800 text-[9px] font-bold text-slate-400"
                           >
                             <ArenaPortraitImg
-                              src={p.image}
+                              src={normalizeWebMediaUrl(p.image)}
                               loading="lazy"
                               decoding="async"
                               className="h-full w-full object-cover"

--- a/components/arenaFlow/ArenaCreateCardModal.tsx
+++ b/components/arenaFlow/ArenaCreateCardModal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { normalizeWebMediaUrl } from '../../services/mediaUrl';
 import { AnimatePresence, motion } from 'framer-motion';
 import { ImageIcon, Plus, ShieldCheck, X } from 'lucide-react';
 import type { RankItem } from '../../pages/RankedList';
@@ -311,7 +312,7 @@ const FormBody: React.FC<FormProps> = ({
             aria-hidden
           >
             {image.trim() && HTTP_URL_RE.test(image.trim()) ? (
-              <img src={image.trim()} alt="" className="h-full w-full object-cover" />
+              <img src={normalizeWebMediaUrl(image.trim())} alt="" className="h-full w-full object-cover" />
             ) : (
               <ImageIcon className="h-5 w-5 text-slate-700" strokeWidth={1.6} />
             )}

--- a/components/arenaFlow/ArenaCurateStack.tsx
+++ b/components/arenaFlow/ArenaCurateStack.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { normalizeWebMediaUrl } from '../../services/mediaUrl';
 import { AnimatePresence, motion, useMotionValue, useTransform, type PanInfo } from 'framer-motion';
 import {
   ArrowRight,
@@ -582,7 +583,7 @@ const SwipeCard = React.memo<SwipeCardProps>(function SwipeCard({
           >
             <CornerTicks color={deck.hex} />
             <ArenaPortraitImg
-              src={item.image}
+              src={normalizeWebMediaUrl(item.image)}
               className="h-full w-full object-cover"
               loading="eager"
               decoding="async"

--- a/components/arenaFlow/ArenaRankDeck.tsx
+++ b/components/arenaFlow/ArenaRankDeck.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
+import { normalizeWebMediaUrl } from '../../services/mediaUrl';
 import { Reorder, motion, useDragControls } from 'framer-motion';
 import {
   ArrowRight,
@@ -214,7 +215,7 @@ const RankRow: React.FC<RowProps> = ({
           >
             <CornerTicks color={deck.hex} />
             <ArenaPortraitImg
-              src={it.image}
+              src={normalizeWebMediaUrl(it.image)}
               className="h-full w-full object-cover"
               loading="lazy"
               draggable={false}

--- a/pages/AgentProfile.tsx
+++ b/pages/AgentProfile.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { normalizeWebMediaUrl } from '../services/mediaUrl';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Shield, Share2, Layers, ArrowUpRight, CheckCircle, User, AlertCircle, RefreshCw } from 'lucide-react';
 import { getAgentById, getAgentTriples } from '../services/graphql';
@@ -160,7 +161,7 @@ const AgentProfile: React.FC = () => {
         <div className="relative z-10 flex flex-col md:flex-row gap-8 items-center md:items-start">
           <div className="w-32 h-32 bg-black border-2 border-intuition-primary flex items-center justify-center text-4xl font-bold text-white shadow-[0_0_20px_rgba(6,182,212,0.3)] overflow-hidden clip-path-slant group">
             {agent.image ? (
-                <img src={agent.image} alt={agent.label} className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-500" />
+                <img src={normalizeWebMediaUrl(agent.image)} alt={agent.label} className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-500" />
             ) : (
                 <User size={48} className="text-slate-700"/>
             )}

--- a/pages/Agents.tsx
+++ b/pages/Agents.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { normalizeWebMediaUrl } from '../services/mediaUrl';
 import { Link } from 'react-router-dom';
 import { Search, ExternalLink, User, Shield } from 'lucide-react';
 import { getAllAgents } from '../services/graphql';
@@ -69,7 +70,7 @@ const Agents: React.FC = () => {
                 <div className="flex items-center gap-3">
                   <div className="w-12 h-12 rounded-full bg-gradient-to-br from-slate-800 to-slate-900 flex items-center justify-center border border-white/10 text-intuition-primary overflow-hidden">
                     {agent.image ? (
-                      <img src={agent.image} alt={agent.label} className="w-full h-full object-cover" />
+                      <img src={normalizeWebMediaUrl(agent.image)} alt={agent.label} className="w-full h-full object-cover" />
                     ) : (
                       <User size={24} />
                     )}

--- a/pages/Compare.tsx
+++ b/pages/Compare.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react';
+import { normalizeWebMediaUrl } from '../services/mediaUrl';
 import { Search, Activity, Zap, Trophy, Brain, Loader2, Quote, Terminal, Crosshair, Network, Shield, Users, BarChart3, TrendingUp, Swords } from 'lucide-react';
 import { getAllAgents, getRedemptionCountForVault } from '../services/graphql';
 import { Account } from '../types';
@@ -194,7 +195,7 @@ const PokeBallArena: React.FC<{
                         </div>
                         <div className="relative h-28 max-md:max-h-[7.5rem] sm:h-40 flex items-center justify-center p-3 sm:p-4">
                             <div className={`absolute inset-0 opacity-20 ${isRed ? 'bg-red-500' : 'bg-blue-500'}`} />
-                            {agent.image ? <img src={agent.image} alt={agent.label} className="relative z-10 w-full h-full object-cover rounded-lg" /> : (
+                            {agent.image ? <img src={normalizeWebMediaUrl(agent.image)} alt={agent.label} className="relative z-10 w-full h-full object-cover rounded-lg" /> : (
                                 <div className="relative z-10 w-20 h-20 rounded-full bg-black/60 flex items-center justify-center text-2xl font-black text-white/60">{agent.label?.slice(0, 2)}</div>
                             )}
                         </div>
@@ -596,7 +597,7 @@ const Compare: React.FC = () => {
                                 >
                                     <div className="flex items-center gap-5">
                                         <div className="w-12 h-12 bg-black border border-slate-800 flex items-center justify-center overflow-hidden shrink-0 group-hover:border-amber-500/50 transition-all shadow-xl">
-                                            {a.image ? <img src={a.image} className="w-full h-full object-cover grayscale group-hover:grayscale-0"/> : <div className="text-xs font-black text-slate-700">{a.label?.[0]}</div>}
+                                            {a.image ? <img src={normalizeWebMediaUrl(a.image)} className="w-full h-full object-cover grayscale group-hover:grayscale-0"/> : <div className="text-xs font-black text-slate-700">{a.label?.[0]}</div>}
                                         </div>
                                         <div>
                                             <div className="font-black text-sm text-white group-hover:text-amber-400 transition-colors uppercase leading-none mb-1.5 tracking-tight">{a.label}</div>

--- a/pages/CreateSignal.tsx
+++ b/pages/CreateSignal.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { normalizeWebMediaUrl } from '../services/mediaUrl';
 import { Link } from 'react-router-dom';
 import { useAccount } from 'wagmi';
 import { ArrowLeft, Terminal, Zap, Loader2, Database, GitBranch, Search, Camera, CheckCircle, ExternalLink, UserPlus, FileText, Sparkles, Info } from 'lucide-react';
@@ -1205,7 +1206,7 @@ const CreateSignal: React.FC = () => {
                         <button key={a.id} type="button" onClick={() => pickNode(nodeSearchOpen!, a.id, a.label)} className="w-full text-left p-3 rounded-2xl bg-white/5 hover:bg-white/15 border border-white/10 hover:border-intuition-primary/40 flex items-center gap-3 transition-all">
                           <div className="shrink-0 w-10 h-10 rounded-xl bg-white/10 overflow-hidden flex items-center justify-center">
                             {a.image ? (
-                              <img src={a.image} alt="" className="w-full h-full object-cover" />
+                              <img src={normalizeWebMediaUrl(a.image)} alt="" className="w-full h-full object-cover" />
                             ) : (
                               <span className="text-lg font-black text-intuition-primary/60">{String(a.label || '?')[0]}</span>
                             )}
@@ -1415,7 +1416,7 @@ const CreateSignal: React.FC = () => {
                         <button key={a.id} type="button" onClick={() => pickNode(nodeSearchOpen!, a.id, a.label)} className="w-full text-left p-3 rounded-2xl bg-white/5 hover:bg-white/15 border border-white/10 hover:border-intuition-primary/40 flex items-center gap-3 transition-all">
                           <div className="shrink-0 w-10 h-10 rounded-xl bg-white/10 overflow-hidden flex items-center justify-center">
                             {a.image ? (
-                              <img src={a.image} alt="" className="w-full h-full object-cover" />
+                              <img src={normalizeWebMediaUrl(a.image)} alt="" className="w-full h-full object-cover" />
                             ) : (
                               <span className="text-lg font-black text-intuition-primary/60">{String(a.label || '?')[0]}</span>
                             )}

--- a/pages/Dashboard.tsx
+++ b/pages/Dashboard.tsx
@@ -1,5 +1,6 @@
 
 import React, { useEffect, useState } from 'react';
+import { normalizeWebMediaUrl } from '../services/mediaUrl';
 import { useAccount } from 'wagmi';
 import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import { connectWallet, getConnectedAccount, getWalletBalance, getLocalTransactions, getShareBalance, getQuoteRedeem } from '../services/web3';
@@ -273,7 +274,7 @@ const Dashboard: React.FC = () => {
                 >
                   <td className="px-6 py-4">
                     <Link to={`/markets/${pos.id}`} className="flex items-center gap-3">
-                      {pos.atom?.image && <img src={pos.atom.image} className="w-8 h-8 rounded-sm object-cover border border-intuition-primary/30" alt="" />}
+                      {pos.atom?.image && <img src={normalizeWebMediaUrl(pos.atom.image)} className="w-8 h-8 rounded-sm object-cover border border-intuition-primary/30" alt="" />}
                       <div className={`font-bold group-hover:text-intuition-primary transition-colors text-glow ${isOpposition ? 'text-intuition-danger' : 'text-white'}`}>{pos.atom?.label}</div>
                     </Link>
                   </td>

--- a/pages/KPIDashboard.tsx
+++ b/pages/KPIDashboard.tsx
@@ -1,5 +1,6 @@
 
 import React, { useEffect, useState, useRef, useCallback } from 'react';
+import { normalizeWebMediaUrl } from '../services/mediaUrl';
 import { Link } from 'react-router-dom';
 import { Shield, Activity, Users, Zap, Download, RefreshCw, FileText, Globe, Terminal, Award, ArrowUpRight, BarChart3, TrendingUp, Loader2, UserCircle, BadgeCheck, Network, Lock, Coins, Clock, Box, ShieldCheck, ExternalLink } from 'lucide-react';
 import { getNetworkKPIs, getRecentFeeProxyActivity, type FeeProxyActivityLine } from '../services/graphql';
@@ -239,7 +240,7 @@ const KPIDashboard: React.FC = () => {
                                                     <td className="px-3 sm:px-4 py-5 min-w-0">
                                                         <div className="flex items-center gap-3 sm:gap-4 min-w-0">
                                                             <div className="w-10 h-10 bg-black border border-slate-800 clip-path-slant flex items-center justify-center overflow-hidden group-hover:border-intuition-secondary transition-all shrink-0">
-                                                                {user.image ? <img src={user.image} className="w-full h-full object-cover" alt="" /> : <UserCircle size={20} className="text-slate-600" />}
+                                                                {user.image ? <img src={normalizeWebMediaUrl(user.image)} className="w-full h-full object-cover" alt="" /> : <UserCircle size={20} className="text-slate-600" />}
                                                             </div>
                                                             <div className="min-w-0 flex-1">
                                                                 <div className="text-sm font-semibold text-white group-hover:text-intuition-secondary transition-colors truncate">{user.label || user.id.slice(0, 14)}</div>

--- a/pages/MarketDetail.tsx
+++ b/pages/MarketDetail.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useMemo, useRef } from 'react';
+import { normalizeWebMediaUrl } from '../services/mediaUrl';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { useAccount } from 'wagmi';
@@ -207,7 +208,7 @@ const AgentShareModal: React.FC<{
                             style={{ borderColor: `${theme.color}66`, boxShadow: `0 0 30px ${theme.bgGlow}` }}
                         >
                             {agent.image ? (
-                              <img src={agent.image} className="w-full h-full object-cover" crossOrigin="anonymous" alt="" />
+                              <img src={normalizeWebMediaUrl(agent.image)} className="w-full h-full object-cover" crossOrigin="anonymous" alt="" />
                             ) : (
                               <Logo className="w-8 h-8 sm:w-10 sm:h-10 transition-colors duration-1000" style={{ filter: `drop-shadow(0 0 8px ${theme.color})` }} />
                             )}
@@ -1152,7 +1153,7 @@ const MarketDetail: React.FC = () => {
                         <div className="mt-1.5 min-w-0">
                             {agent.creator?.id && !isProtocolRouterAddress(agent.creator.id) ? (
                                 <a href={`${EXPLORER_URL}/address/${agent.creator.id}`} target="_blank" rel="noreferrer" onClick={playClick} className="group/creator flex min-w-0 items-center gap-1.5">
-                                    <div className="h-5 w-5 shrink-0 overflow-hidden rounded-full border border-white/20 bg-slate-900"><img src={agent.creator?.image || DEFAULT_PROFILE_AVATAR_URL} className="h-full w-full object-cover" alt="" /></div>
+                                    <div className="h-5 w-5 shrink-0 overflow-hidden rounded-full border border-white/20 bg-slate-900"><img src={normalizeWebMediaUrl(agent.creator?.image || DEFAULT_PROFILE_AVATAR_URL)} className="h-full w-full object-cover" alt="" /></div>
                                     <span className="min-w-0 truncate text-[10px] font-black text-white group-hover/creator:text-intuition-primary">{agent.creator?.label || agent.creator?.id?.slice(0, 10)}</span>
                                     <ExternalLink size={9} className="shrink-0 text-slate-600" />
                                 </a>
@@ -1201,7 +1202,7 @@ const MarketDetail: React.FC = () => {
                     <span className="text-[9px] font-black uppercase tracking-[0.2em] text-slate-500">Creator</span>
                     {agent.creator?.id && !isProtocolRouterAddress(agent.creator.id) ? (
                         <a href={`${EXPLORER_URL}/address/${agent.creator.id}`} target="_blank" rel="noreferrer" onClick={playClick} onMouseEnter={playHover} className="group/creator flex items-center gap-2.5 rounded-full border border-white/10 bg-white/5 px-4 py-1.5 transition-all hover:border-intuition-primary/40 cursor-pointer">
-                            <div className="h-5 w-5 shrink-0 overflow-hidden rounded-full border border-white/20 bg-slate-900 shadow-glow-blue"><img src={agent.creator?.image || DEFAULT_PROFILE_AVATAR_URL} className="h-full w-full object-cover" alt="" /></div>
+                            <div className="h-5 w-5 shrink-0 overflow-hidden rounded-full border border-white/20 bg-slate-900 shadow-glow-blue"><img src={normalizeWebMediaUrl(agent.creator?.image || DEFAULT_PROFILE_AVATAR_URL)} className="h-full w-full object-cover" alt="" /></div>
                             <span className="text-[10px] font-black text-white transition-colors group-hover/creator:text-intuition-primary">{agent.creator?.label || agent.creator?.id?.slice(0, 14)}</span>
                             <ExternalLink size={10} className="text-slate-600 group-hover/creator:text-intuition-primary" />
                         </a>
@@ -1230,7 +1231,7 @@ const MarketDetail: React.FC = () => {
                     <div className="relative shrink-0">
                         <div className="absolute -inset-3 blur-2xl opacity-0 transition-opacity duration-1000 group-hover/header:opacity-100" style={{ backgroundColor: `${theme.color}33` }}></div>
                         <div className="flex h-16 w-16 items-center justify-center overflow-hidden rounded-xl border-2 bg-slate-950 shadow-2xl sm:h-20 sm:w-20 sm:rounded-2xl" style={{ borderColor: `${theme.color}66` }}>
-                            {agent.image ? <img src={agent.image} alt={agent.label} className="h-full w-full object-cover" /> : <User size={32} className="text-slate-800 sm:h-10 sm:w-10" />}
+                            {agent.image ? <img src={normalizeWebMediaUrl(agent.image)} alt={agent.label} className="h-full w-full object-cover" /> : <User size={32} className="text-slate-800 sm:h-10 sm:w-10" />}
                         </div>
                     </div>
                     <div className="min-w-0 flex-1 space-y-2">
@@ -1293,7 +1294,7 @@ const MarketDetail: React.FC = () => {
                     <div className="relative shrink-0">
                         <div className="absolute -inset-6 blur-2xl opacity-0 transition-opacity duration-1000 group-hover/header:opacity-100" style={{ backgroundColor: `${theme.color}33` }}></div>
                         <div className="flex h-28 w-28 items-center justify-center overflow-hidden rounded-2xl border-2 bg-slate-950 shadow-2xl transition-all duration-500 group-hover/header:scale-105" style={{ borderColor: `${theme.color}66` }}>
-                            {agent.image ? <img src={agent.image} alt={agent.label} className="h-full w-full object-cover transition-transform duration-1000 group-hover/header:scale-110" /> : <User size={52} className="text-slate-800" />}
+                            {agent.image ? <img src={normalizeWebMediaUrl(agent.image)} alt={agent.label} className="h-full w-full object-cover transition-transform duration-1000 group-hover/header:scale-110" /> : <User size={52} className="text-slate-800" />}
                         </div>
                     </div>
                     <div className="min-w-0 flex-1">
@@ -1941,7 +1942,7 @@ const MarketDetail: React.FC = () => {
                                             <td className="px-1.5 py-2.5 sm:px-6 md:px-8 sm:py-6 min-w-0">
                                                 <Link to={`/profile/${h.account.id}`} className="flex items-center gap-1.5 sm:gap-4 group-hover:text-white transition-colors min-w-0">
                                                     <div className="w-6 h-6 sm:w-8 sm:h-8 rounded-lg sm:rounded-xl bg-slate-900 border border-slate-800 flex items-center justify-center overflow-hidden group-hover:border-white transition-all shadow-xl shrink-0">
-                                                        {h.account.image ? <img src={h.account.image} className="w-full h-full object-cover" alt="" /> : <User size={11} className="text-slate-700 sm:w-[14px] sm:h-[14px]" />}
+                                                        {h.account.image ? <img src={normalizeWebMediaUrl(h.account.image)} className="w-full h-full object-cover" alt="" /> : <User size={11} className="text-slate-700 sm:w-[14px] sm:h-[14px]" />}
                                                     </div>
                                                     <span className="font-black text-white group-hover:text-glow-white transition-colors uppercase tracking-tight truncate min-w-0" title={h.account.label || h.account.id}>{h.account.label || `${h.account.id.slice(0, 8)}…`}</span>
                                                 </Link>
@@ -1969,7 +1970,7 @@ const MarketDetail: React.FC = () => {
                 {activeTab === 'IDENTITIES' && (
                     <div>
                         <h4 className="text-[11px] font-black text-slate-500 uppercase tracking-[0.6em] mb-10 flex items-center gap-4"><Fingerprint size={16}/> Neural Identities Engaged</h4>
-                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">{engagedIdentities.length > 0 ? engagedIdentities.map((peer, i) => (<Link key={i} to={`/markets/${peer.term_id}`} className="p-6 bg-white/[0.02] border-2 border-slate-900 hover:border-white/40 transition-all rounded-2xl group relative overflow-hidden backdrop-blur-sm"><div className="absolute inset-0 bg-gradient-to-br from-white/5 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity"></div><div className="flex items-center justify-between gap-6 relative z-10"><div className="flex items-center gap-5"><div className="w-14 h-14 bg-black border-2 border-slate-800 rounded-2xl overflow-hidden group-hover:border-white transition-all shadow-xl group-hover:shadow-glow-white">{peer.image ? <img src={peer.image} className="w-full h-full object-cover" /> : <User size={24} className="text-slate-700" />}</div><div className="min-w-0"><div className="text-sm font-black text-white group-hover:text-glow-white transition-colors uppercase truncate max-w-[140px] font-display tracking-tight leading-none mb-1.5">{peer.label}</div><div className="text-[8px] text-slate-600 uppercase font-black tracking-widest">{peer.predicate || 'REPUTATION_LINK'}</div></div></div><div className="flex flex-col items-end"><div className="text-[10px] font-black text-intuition-success animate-pulse text-glow-success">LIVE</div><span className="text-[8px] font-black text-slate-700 uppercase tracking-widest mt-1">L3_SYNC</span></div></div></Link>)) : (<div className="col-span-full py-20 text-center text-slate-700 uppercase font-black tracking-widest text-[10px] border border-dashed border-slate-900">NULL_IDENTITIES_SYNCED</div>)}</div>
+                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">{engagedIdentities.length > 0 ? engagedIdentities.map((peer, i) => (<Link key={i} to={`/markets/${peer.term_id}`} className="p-6 bg-white/[0.02] border-2 border-slate-900 hover:border-white/40 transition-all rounded-2xl group relative overflow-hidden backdrop-blur-sm"><div className="absolute inset-0 bg-gradient-to-br from-white/5 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity"></div><div className="flex items-center justify-between gap-6 relative z-10"><div className="flex items-center gap-5"><div className="w-14 h-14 bg-black border-2 border-slate-800 rounded-2xl overflow-hidden group-hover:border-white transition-all shadow-xl group-hover:shadow-glow-white">{peer.image ? <img src={normalizeWebMediaUrl(peer.image)} className="w-full h-full object-cover" /> : <User size={24} className="text-slate-700" />}</div><div className="min-w-0"><div className="text-sm font-black text-white group-hover:text-glow-white transition-colors uppercase truncate max-w-[140px] font-display tracking-tight leading-none mb-1.5">{peer.label}</div><div className="text-[8px] text-slate-600 uppercase font-black tracking-widest">{peer.predicate || 'REPUTATION_LINK'}</div></div></div><div className="flex flex-col items-end"><div className="text-[10px] font-black text-intuition-success animate-pulse text-glow-success">LIVE</div><span className="text-[8px] font-black text-slate-700 uppercase tracking-widest mt-1">L3_SYNC</span></div></div></Link>)) : (<div className="col-span-full py-20 text-center text-slate-700 uppercase font-black tracking-widest text-[10px] border border-dashed border-slate-900">NULL_IDENTITIES_SYNCED</div>)}</div>
                     </div>
                 )}
                 {activeTab === 'CLAIMS' && (
@@ -1998,7 +1999,7 @@ const MarketDetail: React.FC = () => {
                                     >
                                         <div className="flex items-start gap-2 min-w-0">
                                           <div className="w-9 h-9 rounded-lg bg-slate-900 border border-slate-800 flex items-center justify-center overflow-hidden shrink-0 mt-0.5">
-                                              {c.subject?.image ? <img src={c.subject.image} alt="" className="w-full h-full object-cover" /> : <User size={16} className="text-slate-500" />}
+                                              {c.subject?.image ? <img src={normalizeWebMediaUrl(c.subject.image)} alt="" className="w-full h-full object-cover" /> : <User size={16} className="text-slate-500" />}
                                           </div>
                                           <div className="min-w-0 flex-1 space-y-2">
                                             <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
@@ -2108,7 +2109,7 @@ const MarketDetail: React.FC = () => {
                                             <td className="px-3 sm:px-6 md:px-8 py-4 sm:py-6">
                                                 <Link to={entryUrl} onClick={(e) => e.stopPropagation()} className="flex items-center gap-4 group/entry">
                                                     <div className="w-10 h-10 bg-slate-900 border border-slate-800 flex items-center justify-center rounded-2xl overflow-hidden group-hover/entry:border-white/40 transition-colors shrink-0">
-                                                        {entry.image ? <img src={entry.image} alt="" className="w-full h-full object-cover" /> : <User size={18} className="text-slate-400" />}
+                                                        {entry.image ? <img src={normalizeWebMediaUrl(entry.image)} alt="" className="w-full h-full object-cover" /> : <User size={18} className="text-slate-400" />}
                                                     </div>
                                                     <div>
                                                         <div className="text-sm font-black text-white group-hover/entry:text-glow-white transition-colors uppercase truncate max-w-[200px] font-display tracking-tight">{entry.label || entry.id || 'Unknown'}</div>
@@ -2232,7 +2233,7 @@ const MarketDetail: React.FC = () => {
                             <p className="text-sm text-slate-500 font-medium group-hover:text-slate-400 transition-colors">Other markets linked through this graph.</p>
                           </div>
                         </div>
-                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">{engagedIdentities.length > 0 ? engagedIdentities.map((peer, i) => (<Link key={i} to={`/markets/${peer.term_id}`} className="group p-8 bg-black border-2 border-slate-900 hover:border-white transition-all rounded-2xl flex items-center gap-8 relative overflow-hidden shadow-2xl"><div className="absolute inset-0 bg-gradient-to-tr from-white/5 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity"></div><div className="w-16 h-16 bg-slate-950 border-2 border-slate-800 flex items-center justify-center rounded-2xl shrink-0 group-hover:border-white transition-all shadow-2xl overflow-hidden">{peer.image ? <img src={peer.image} className="w-full h-full object-cover" /> : <User size={24} className="text-slate-700" />}</div><div className="min-w-0"><div className="text-lg font-black text-white group-hover:text-glow-white transition-colors truncate leading-none mb-2 tracking-tight">{peer.label}</div><div className="text-[8px] font-semibold text-slate-600 tracking-wide">Related market</div></div></Link>)) : (<div className="col-span-full py-32 text-center text-slate-600 font-medium text-sm border-2 border-dashed border-slate-900 rounded-2xl">No related markets yet</div>)}</div>
+                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">{engagedIdentities.length > 0 ? engagedIdentities.map((peer, i) => (<Link key={i} to={`/markets/${peer.term_id}`} className="group p-8 bg-black border-2 border-slate-900 hover:border-white transition-all rounded-2xl flex items-center gap-8 relative overflow-hidden shadow-2xl"><div className="absolute inset-0 bg-gradient-to-tr from-white/5 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity"></div><div className="w-16 h-16 bg-slate-950 border-2 border-slate-800 flex items-center justify-center rounded-2xl shrink-0 group-hover:border-white transition-all shadow-2xl overflow-hidden">{peer.image ? <img src={normalizeWebMediaUrl(peer.image)} className="w-full h-full object-cover" /> : <User size={24} className="text-slate-700" />}</div><div className="min-w-0"><div className="text-lg font-black text-white group-hover:text-glow-white transition-colors truncate leading-none mb-2 tracking-tight">{peer.label}</div><div className="text-[8px] font-semibold text-slate-600 tracking-wide">Related market</div></div></Link>)) : (<div className="col-span-full py-32 text-center text-slate-600 font-medium text-sm border-2 border-dashed border-slate-900 rounded-2xl">No related markets yet</div>)}</div>
                     </div>
                 )}
               </motion.div>

--- a/pages/Markets.tsx
+++ b/pages/Markets.tsx
@@ -1,5 +1,6 @@
 
 import React, { useEffect, useState, useMemo, useRef, useCallback } from 'react';
+import { normalizeWebMediaUrl } from '../services/mediaUrl';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useAccount } from 'wagmi';
 import { Search, TrendingUp, Filter, Tag, Zap, Activity, ShieldCheck, Loader2, Database, ChevronDown, ChevronLeft, ChevronRight, Star, LayoutGrid, Hexagon, Network, Layers, ArrowRight, Shield, User, Globe, Cpu, Component, Boxes, ScanSearch, Hash, Users, BadgeCheck, UserCog, List, Trophy } from 'lucide-react';
@@ -724,7 +725,7 @@ const Markets: React.FC = () => {
                         <td className="px-6 py-2">
                           <div className="flex items-center gap-3 py-4">
                             <div className="w-10 h-10 bg-slate-950 flex items-center justify-center overflow-hidden border border-slate-800 rounded-xl">
-                              {list.image ? <img src={list.image} className="w-full h-full object-cover" alt="" /> : <Component size={18} className="text-slate-600" />}
+                              {list.image ? <img src={normalizeWebMediaUrl(list.image)} className="w-full h-full object-cover" alt="" /> : <Component size={18} className="text-slate-600" />}
                             </div>
                             <span className="font-black text-white text-[11px] uppercase truncate max-w-[200px]">{list.label || 'Untitled list'}</span>
                           </div>
@@ -771,7 +772,7 @@ const Markets: React.FC = () => {
                               <div className="absolute inset-0 bg-intuition-primary blur-[20px] opacity-20 group-hover:opacity-35 transition-all duration-500 rounded-full scale-110" />
                               <div className="relative w-12 h-12 md:w-20 md:h-20 rounded-xl md:rounded-2xl bg-black/80 border-2 border-slate-700 group-hover:border-intuition-primary/60 flex items-center justify-center text-slate-500 group-hover:text-intuition-primary transition-all duration-500 overflow-hidden shadow-[0_0_25px_rgba(255,80,57,0.4)]">
                                   {list.image ? (
-                                      <img src={list.image} className="w-full h-full object-cover grayscale group-hover:grayscale-0 group-hover:scale-110 transition-all duration-500" alt="" />
+                                      <img src={normalizeWebMediaUrl(list.image)} className="w-full h-full object-cover grayscale group-hover:grayscale-0 group-hover:scale-110 transition-all duration-500" alt="" />
                                   ) : (
                                       <Component size={32} className="max-md:w-5 max-md:h-5 group-hover:scale-110 transition-transform duration-500 opacity-70 group-hover:opacity-100" />
                                   )}
@@ -800,7 +801,7 @@ const Markets: React.FC = () => {
                       <div className="hidden sm:flex items-center justify-center -space-x-2 mt-auto relative z-10 group-hover:translate-y-[-2px] transition-transform duration-300 mb-2 md:mb-4">
                           {(list.items || []).slice(0, 5).map((item: any, i: number) => (
                               <div key={i} className="w-9 h-9 rounded-xl border-2 border-slate-800 hover:border-intuition-primary/60 bg-slate-900 flex items-center justify-center overflow-hidden shadow-lg transition-all duration-300 hover:-translate-y-1 hover:z-10">
-                                  {item.image ? <img src={item.image} className="w-full h-full object-cover" alt="" /> : <span className="text-[10px] font-black text-slate-600">{item.label?.[0]}</span>}
+                                  {item.image ? <img src={normalizeWebMediaUrl(item.image)} className="w-full h-full object-cover" alt="" /> : <span className="text-[10px] font-black text-slate-600">{item.label?.[0]}</span>}
                               </div>
                           ))}
                           {(list.totalItems > 5) && (
@@ -871,7 +872,7 @@ const Markets: React.FC = () => {
                     <div className="flex gap-3 min-w-0">
                       <div className="h-11 w-11 shrink-0 rounded-xl bg-slate-950 border border-slate-800 flex items-center justify-center overflow-hidden">
                         {claim.subject?.image ? (
-                          <img src={claim.subject.image} className="h-full w-full object-cover" alt="" />
+                          <img src={normalizeWebMediaUrl(claim.subject.image)} className="h-full w-full object-cover" alt="" />
                         ) : (
                           <User size={18} className="text-slate-600" />
                         )}
@@ -972,7 +973,7 @@ const Markets: React.FC = () => {
                                 <td className="px-4 py-3 align-middle">
                                     <div className="flex items-center gap-2 sm:gap-3 min-w-0">
                                         <div className="w-9 h-9 rounded-lg bg-slate-950 border border-slate-800 flex items-center justify-center overflow-hidden shrink-0">
-                                            {claim.subject?.image ? <img src={claim.subject.image} className="w-full h-full object-cover" alt="" /> : <User size={16} className="text-slate-700" />}
+                                            {claim.subject?.image ? <img src={normalizeWebMediaUrl(claim.subject.image)} className="w-full h-full object-cover" alt="" /> : <User size={16} className="text-slate-700" />}
                                         </div>
                                         <span className="font-bold text-white text-sm truncate" title={claim.subject?.label || ''}>{claim.subject?.label || '—'}</span>
                                         <span className="text-slate-500 text-xs shrink-0">{(claim.predicate || 'LINK').replace(/_/g, ' ').toLowerCase()}</span>
@@ -1063,7 +1064,7 @@ const Markets: React.FC = () => {
                         <div className="absolute -inset-1 rounded-2xl bg-black/60" />
                         <div className={`relative h-11 w-11 border border-white/10 bg-black/80 sm:h-16 sm:w-16 sm:rounded-2xl flex items-center justify-center overflow-hidden rounded-xl shadow-[0_12px_30px_rgba(0,0,0,0.9)]`}>
                           {agent.image ? (
-                             <img src={agent.image} alt={agent.label} className="w-full h-full object-cover grayscale group-hover:grayscale-0 transition-all duration-700" />
+                             <img src={normalizeWebMediaUrl(agent.image)} alt={agent.label} className="w-full h-full object-cover grayscale group-hover:grayscale-0 transition-all duration-700" />
                           ) : (
                              <div className={`text-lg font-black sm:text-3xl ${tierStyle.color}`}>{agent.label?.[0]?.toUpperCase()}</div>
                           )}

--- a/pages/Portfolio.tsx
+++ b/pages/Portfolio.tsx
@@ -21,6 +21,7 @@ const EquityChartTooltip = ({ active, payload }: any) => {
 import { formatEther, getAddress } from 'viem';
 import { connectWallet, getConnectedAccount, getWalletBalance, getShareBalancesBatch, getLocalTransactions } from '../services/web3';
 import { getUserPositions, getPortfolioPositionsWithValue, getUserHistory, getVaultsByIds, getAccountPnlCurrent, getCurveLabel, getMyCreated, resolveMetadata } from '../services/graphql';
+import { normalizeWebMediaUrl } from '../services/mediaUrl';
 import { Wallet, RefreshCw, Zap, User, Loader2, TrendingUp, Coins, Lock, Activity as PulseIcon, Clock, Terminal, Globe, Layers, LogOut, Sparkles, ChevronDown } from 'lucide-react';
 import { Transaction } from '../types';
 import { toast } from '../components/Toast';
@@ -728,7 +729,7 @@ const Portfolio: React.FC = () => {
                 <div className="flex items-center gap-3 min-w-0">
                   <div className="w-12 h-12 rounded-2xl bg-black/80 border border-white/15 flex items-center justify-center overflow-hidden shrink-0">
                     {sharePosition.atom?.image ? (
-                      <img src={sharePosition.atom.image} alt="" className="w-full h-full object-cover" />
+                      <img src={normalizeWebMediaUrl(sharePosition.atom.image)} alt="" className="w-full h-full object-cover" />
                     ) : (
                       <User className="w-5 h-5 text-slate-500" />
                     )}
@@ -898,7 +899,7 @@ const Portfolio: React.FC = () => {
                         <Link to={`/markets/${pos.id}`} className="flex gap-3 min-w-0">
                           <div className="h-11 w-11 shrink-0 rounded-xl border border-slate-800 bg-slate-900 overflow-hidden">
                             {pos.atom?.image ? (
-                              <img src={pos.atom.image} className="h-full w-full object-cover" alt="" />
+                              <img src={normalizeWebMediaUrl(pos.atom.image)} className="h-full w-full object-cover" alt="" />
                             ) : (
                               <div className="flex h-full w-full items-center justify-center">
                                 <User className="h-5 w-5 text-slate-600" />
@@ -997,7 +998,7 @@ const Portfolio: React.FC = () => {
                         <td className="px-2 sm:px-3 md:px-4 xl:px-5 py-4 sm:py-5 md:py-6 min-w-0 overflow-hidden align-top">
                           <Link to={`/markets/${pos.id}`} className="flex items-center gap-2 sm:gap-4 min-w-0">
                             <div className="w-8 h-8 sm:w-9 sm:h-9 xl:w-11 xl:h-11 bg-slate-900 border border-slate-800 rounded-xl sm:rounded-2xl flex items-center justify-center overflow-hidden group-hover:border-intuition-primary transition-all shrink-0">
-                              {pos.atom.image ? <img src={pos.atom.image} className="w-full h-full object-cover" alt="" /> : <User className="w-4 h-4 sm:w-[18px] sm:h-[18px] text-slate-700" />}
+                              {pos.atom.image ? <img src={normalizeWebMediaUrl(pos.atom.image)} className="w-full h-full object-cover" alt="" /> : <User className="w-4 h-4 sm:w-[18px] sm:h-[18px] text-slate-700" />}
                             </div>
                             <div className="min-w-0 flex-1">
                               <div className={`font-black uppercase text-xs sm:text-sm xl:text-base group-hover:text-intuition-primary transition-colors truncate ${isOpposition ? 'text-intuition-danger' : 'text-white'}`} title={pos.atom.label}>{pos.atom.label}</div>
@@ -1307,7 +1308,7 @@ const Portfolio: React.FC = () => {
                         >
                           <div className="flex items-center gap-2 min-w-0">
                             <div className="w-8 h-8 bg-slate-900 border border-slate-800 rounded-lg flex items-center justify-center overflow-hidden shrink-0 group-hover:border-intuition-primary transition-all">
-                              {item.image ? <img src={item.image} className="w-full h-full object-cover" alt="" /> : <User className="w-4 h-4 text-slate-700" />}
+                              {item.image ? <img src={normalizeWebMediaUrl(item.image)} className="w-full h-full object-cover" alt="" /> : <User className="w-4 h-4 text-slate-700" />}
                             </div>
                             <div className="min-w-0">
                               <div className="font-black text-white text-xs truncate group-hover:text-intuition-primary transition-colors">{item.label}</div>
@@ -1335,7 +1336,7 @@ const Portfolio: React.FC = () => {
                         >
                           <div className="flex items-center gap-2 min-w-0">
                             <div className="w-8 h-8 bg-slate-900 border border-slate-800 rounded-lg flex items-center justify-center overflow-hidden shrink-0 group-hover:border-intuition-primary transition-all">
-                              {item.image ? <img src={item.image} className="w-full h-full object-cover" alt="" /> : <Globe className="w-4 h-4 text-slate-700" />}
+                              {item.image ? <img src={normalizeWebMediaUrl(item.image)} className="w-full h-full object-cover" alt="" /> : <Globe className="w-4 h-4 text-slate-700" />}
                             </div>
                             <div className="min-w-0">
                               <div className="font-black text-white text-xs truncate group-hover:text-intuition-primary transition-colors">{item.label}</div>

--- a/pages/PublicProfile.tsx
+++ b/pages/PublicProfile.tsx
@@ -1,5 +1,6 @@
 
 import React, { useEffect, useState, useCallback, useMemo, useRef } from 'react';
+import { normalizeWebMediaUrl } from '../services/mediaUrl';
 import { createPortal } from 'react-dom';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { useAccount } from 'wagmi';
@@ -1185,7 +1186,7 @@ const PublicProfile: React.FC = () => {
                               <td className="px-3 sm:px-6 md:px-10 py-4 md:py-6">
                                   <Link to={`/markets/${p.id}`} className="flex items-center gap-3 sm:gap-6 group-hover:text-intuition-primary transition-colors">
                                       <div className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-2xl border-2 border-slate-800 bg-slate-900/80 shadow-lg transition-all group-hover:border-intuition-primary sm:h-12 sm:w-12">
-                                          {p.atom?.image ? <img src={p.atom.image} className="w-full h-full object-cover" /> : <User size={20} className="text-slate-700" />}
+                                          {p.atom?.image ? <img src={normalizeWebMediaUrl(p.atom.image)} className="w-full h-full object-cover" /> : <User size={20} className="text-slate-700" />}
                                       </div>
                                       <div>
                                           <div className={`font-black text-sm group-hover:text-intuition-primary transition-colors uppercase leading-none mb-1.5 tracking-tight ${p.atom?.type === 'CLAIM' ? 'text-intuition-danger' : 'text-white'}`}>{p.atom?.label || p.id.slice(0,8)}</div>

--- a/pages/RankedList.tsx
+++ b/pages/RankedList.tsx
@@ -1,5 +1,6 @@
 /** Arena: local stance grid + arena points. Vaults: /markets/:id */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { normalizeWebMediaUrl } from '../services/mediaUrl';
 import { motion, useReducedMotion } from 'framer-motion';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useAccount } from 'wagmi';
@@ -818,7 +819,7 @@ function ArenaLaneCard({
               <div className="-space-x-2 flex items-center">
                 <div className="relative z-[2] h-10 w-10 overflow-hidden rounded-lg border border-white/12 bg-black/70 sm:h-11 sm:w-11">
                   <ArenaPortraitImg
-                    src={item.image}
+                    src={normalizeWebMediaUrl(item.image)}
                     className="h-full w-full object-cover grayscale transition-all duration-500 group-hover:grayscale-0"
                     loading="lazy"
                   >
@@ -838,7 +839,7 @@ function ArenaLaneCard({
             ) : (
               <div className="relative h-10 w-10 overflow-hidden rounded-lg border border-white/12 bg-black/70 sm:h-11 sm:w-11">
                 <ArenaPortraitImg
-                  src={item.image}
+                  src={normalizeWebMediaUrl(item.image)}
                   className="h-full w-full object-cover grayscale transition-all duration-700 group-hover:grayscale-0"
                   loading="lazy"
                 >
@@ -4669,7 +4670,7 @@ const RankedList: React.FC = () => {
                           >
                             <div className="flex items-start gap-2.5">
                               <div className="relative h-10 w-10 shrink-0 rounded-2xl overflow-hidden ring-1 ring-white/15 bg-gradient-to-br from-slate-800 to-slate-950 shadow-inner">
-                                <ArenaPortraitImg src={p.image} className="h-full w-full object-cover">
+                                <ArenaPortraitImg src={normalizeWebMediaUrl(p.image)} className="h-full w-full object-cover">
                                   <div className="h-full w-full flex items-center justify-center text-sm font-black text-intuition-primary/90">
                                     {leaderboardAvatarGlyph(p.label)}
                                   </div>

--- a/services/mediaUrl.ts
+++ b/services/mediaUrl.ts
@@ -1,6 +1,7 @@
 /** Default gateways — browser-friendly `https` equivalents for decentralized schemes. */
 
-const CLOUDFLARE_IPFS_GATEWAY = 'https://cloudflare-ipfs.com/ipfs/';
+// Cloudflare sunset cloudflare-ipfs.com (2024) — use the public ipfs.io gateway (CORS-enabled, https).
+const IPFS_GATEWAY = 'https://ipfs.io/ipfs/';
 
 /** Turn protocol-native / bare media URLs into something `<img>` can load. */
 export function normalizeWebMediaUrl(raw: string | null | undefined): string | undefined {
@@ -13,14 +14,14 @@ export function normalizeWebMediaUrl(raw: string | null | undefined): string | u
     if (u.startsWith('ipfs://')) {
       const path = u.slice('ipfs://'.length).replace(/^\/+/, '').replace(/^ipfs\//, '');
       if (!path) return undefined;
-      return `${CLOUDFLARE_IPFS_GATEWAY}${path}`;
+      return `${IPFS_GATEWAY}${path}`;
     }
 
     const lowerProto = /^([a-z+.-]+):\/\//i.exec(u)?.[1]?.toLowerCase();
     if (lowerProto === 'ipfs') {
       const rest = u.replace(/^ipfs:\/\//i, '').replace(/^\/+/, '');
       if (!rest) return undefined;
-      return `${CLOUDFLARE_IPFS_GATEWAY}${rest.replace(/^ipfs\//, '')}`;
+      return `${IPFS_GATEWAY}${rest.replace(/^ipfs\//, '')}`;
     }
 
     if (lowerProto === 'ar' || u.startsWith('ar://')) {
@@ -32,15 +33,15 @@ export function normalizeWebMediaUrl(raw: string | null | undefined): string | u
 
     ///ipfs/Qm… or /ipfs/bafy…
     const slashIpfs = u.match(/^\/ipfs\/(.+)/i)?.[1];
-    if (slashIpfs) return `${CLOUDFLARE_IPFS_GATEWAY}${slashIpfs.replace(/^ipfs\//, '')}`;
+    if (slashIpfs) return `${IPFS_GATEWAY}${slashIpfs.replace(/^ipfs\//, '')}`;
 
     // Bare CIDv0 / v1 (common in metadata payloads)
     if (/^Qm[1-9A-HJ-NP-Za-km-z]{44}$/.test(u) || /^baf[a-z2-7]{50,}$/i.test(u)) {
-      return `${CLOUDFLARE_IPFS_GATEWAY}${u}`;
+      return `${IPFS_GATEWAY}${u}`;
     }
 
     // Relative-ish paths when gateway host already implied (rare)
-    if (/^ipfs\//i.test(u)) return `${CLOUDFLARE_IPFS_GATEWAY}${u.replace(/^ipfs\//i, '')}`;
+    if (/^ipfs\//i.test(u)) return `${IPFS_GATEWAY}${u.replace(/^ipfs\//i, '')}`;
 
     return u;
   } catch {

--- a/services/web3.ts
+++ b/services/web3.ts
@@ -47,10 +47,12 @@ export function setOpenConnectModalRef(fn: (() => void) | null) {
   openConnectModalRef = fn;
 }
 
-// Dedicated client for ENS resolution (Ethereum Mainnet) using a more robust public RPC
+// Dedicated client for ENS resolution (Ethereum Mainnet). Must be a browser-CORS-enabled
+// public RPC — eth.llamarpc.com blocks browser preflights (and was returning 503), which
+// surfaced as "Failed to fetch" CORS noise in the console on every wallet connect.
 const mainnetClient = createPublicClient({
   chain: mainnet,
-  transport: http('https://eth.llamarpc.com'),
+  transport: http('https://ethereum-rpc.publicnode.com'),
 });
 
 type InjectedPreference = 'default' | 'metamask' | 'rabby' | 'brave';


### PR DESCRIPTION
## Fixes the console errors on the live site

**1. IPFS images (dead gateway)** — `cloudflare-ipfs.com` was sunset by Cloudflare (now HTTP 000). Switched `services/mediaUrl.ts` to the `ipfs.io` gateway, and wrapped **every dynamic `<img src>` across 26 files** in `normalizeWebMediaUrl` so a raw `ipfs://` URL can never reach the DOM (it was CSP-blocked on `/portfolio`). Idempotent — the normalizer passes `http/data/blob` through untouched.

**2. ENS RPC (no CORS / 503)** — the Ethereum-mainnet ENS client in `services/web3.ts` used `eth.llamarpc.com`, which is currently HTTP 503 and blocks browser CORS. Switched to `ethereum-rpc.publicnode.com` (ACAO `*`). Removes the `getEnsName` "Failed to fetch" noise on wallet connect.

## Not an app bug (no change)
The remaining GraphQL `No Access-Control-Allow-Origin` errors trace to a **request-intercepting browser extension** wrapping `window.fetch` (stack frames bottom out in `requests.js`/`200.js`, which the app never emits). The endpoint returns correct CORS for the origin (verified) and the app uses native `fetch` — reproduces clean in incognito with extensions off.

## Verification
- `npm run build` ✓ (26s, all chunks emitted)
- `tsc` holds at the 35 pre-existing errors — **zero introduced** (diffed stash vs. working tree; the only deltas are +1 line-number shifts from the added imports)
- Coverage grep: **zero** raw dynamic `<img>` remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)